### PR TITLE
Use build flags for full-width apps

### DIFF
--- a/software/o_c_REV/APP_ENIGMA.ino
+++ b/software/o_c_REV/APP_ENIGMA.ino
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#ifdef ENABLE_APP_ENIGMA
+
 #include "OC_strings.h"
 #include "HSApplication.h"
 #include "HSMIDI.h"
@@ -1235,3 +1237,4 @@ void EnigmaTMWS_handleEncoderEvent(const UI::Event &event) {
 }
 
 
+#endif

--- a/software/o_c_REV/APP_MIDI.ino
+++ b/software/o_c_REV/APP_MIDI.ino
@@ -22,6 +22,8 @@
 
 // See https://www.pjrc.com/teensy/td_midi.html
 
+#ifdef ENABLE_APP_MIDI
+
 #include "HSApplication.h"
 #include "HSMIDI.h"
 
@@ -907,3 +909,4 @@ void MIDI_handleEncoderEvent(const UI::Event &event) {
 }
 
 
+#endif

--- a/software/o_c_REV/APP_NeuralNetwork.ino
+++ b/software/o_c_REV/APP_NeuralNetwork.ino
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#ifdef ENABLE_APP_NEURAL_NETWORK
+
 #include "HSApplication.h"
 #include "HSMIDI.h"
 #include "neuralnet/LogicGate.h"
@@ -649,3 +651,5 @@ void NeuralNetwork_handleEncoderEvent(const UI::Event &event) {
     // Right encoder turned
     if (event.control == OC::CONTROL_ENCODER_R) NeuralNetwork_instance.OnRightEncoderMove(event.value);
 }
+
+#endif

--- a/software/o_c_REV/APP_PONGGAME.ino
+++ b/software/o_c_REV/APP_PONGGAME.ino
@@ -20,6 +20,8 @@
 //
 // CV-controllable Pong game
 
+#ifdef ENABLE_APP_PONG
+
 #include "OC_DAC.h"
 #include "OC_ADC.h"
 #include "OC_digital_inputs.h"
@@ -367,3 +369,5 @@ void PONGGAME_handleEncoderEvent(const UI::Event &event) {
 	if (event.value > 0) pong_instance.MovePaddleDown();
 	pong_instance.ResetPaddle();
 }
+
+#endif

--- a/software/o_c_REV/APP_THEDARKESTTIMELINE.ino
+++ b/software/o_c_REV/APP_THEDARKESTTIMELINE.ino
@@ -22,6 +22,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#ifdef ENABLE_APP_DARKEST_TIMELINE
+
 #include "util/util_settings.h"
 #include "OC_DAC.h"
 #include "braids_quantizer.h"
@@ -589,3 +591,5 @@ void TheDarkestTimeline_handleEncoderEvent(const UI::Event &event) {
     // Right encoder turned
     if (event.control == OC::CONTROL_ENCODER_R) TheDarkestTimeline_instance.OnRightEncoderMove(event.value);
 }
+
+#endif

--- a/software/o_c_REV/OC_apps.ino
+++ b/software/o_c_REV/OC_apps.ino
@@ -36,13 +36,23 @@
 
 OC::App available_apps[] = {
   DECLARE_APP('H','S', "Hemisphere", HEMISPHERE),
-  // DECLARE_APP('M','I', "Captain MIDI", MIDI),
-  // DECLARE_APP('D','2', "Darkest Timeline", TheDarkestTimeline),
-  // DECLARE_APP('E','N', "Enigma", EnigmaTMWS),
-  // DECLARE_APP('N','N', "Neural Net", NeuralNetwork),
+  #ifdef ENABLE_APP_MIDI
+  DECLARE_APP('M','I', "Captain MIDI", MIDI),
+  #endif
+  #ifdef ENABLE_APP_DARKEST_TIMELINE
+  DECLARE_APP('D','2', "Darkest Timeline", TheDarkestTimeline),
+  #endif
+  #ifdef ENABLE_APP_ENIGMA
+  DECLARE_APP('E','N', "Enigma", EnigmaTMWS),
+  #endif
+  #ifdef ENABLE_APP_NEURAL_NETWORK
+  DECLARE_APP('N','N', "Neural Net", NeuralNetwork),
+  #endif
   DECLARE_APP('S','C', "Scale Editor", SCALEEDITOR),
   DECLARE_APP('W','A', "Waveform Editor", WaveformEditor),
-  // DECLARE_APP('P','O', "Pong", PONGGAME),
+  #ifdef ENABLE_APP_PONG
+  DECLARE_APP('P','O', "Pong", PONGGAME),
+  #endif
   DECLARE_APP('B','R', "Backup / Restore", Backup),
   DECLARE_APP('S','E', "Setup / About", Settings),
 };

--- a/software/o_c_REV/OC_options.h
+++ b/software/o_c_REV/OC_options.h
@@ -24,5 +24,14 @@
 /* ------------ use DAC8564 -------------------------------------------------------------------------  */
 //#define DAC8564
 
+/* Flags for the full-width apps, these enable/disable them in OC_apps.ino but also zero out the app   */
+/* files to prevent them from taking up space. Only Enigma is enabled by default.                      */
+#define ENABLE_APP_ENIGMA
+//#define ENABLE_APP_MIDI
+//#define ENABLE_APP_NEURAL_NETWORK
+//#define ENABLE_APP_PONG
+//#define ENABLE_APP_DARKEST_TIMELINE
+
+
 #endif
 


### PR DESCRIPTION
Use build flags to zero out full-width app files instead of renaming them to .ino.disabled. This also re-enabled the Engima app now that there's space (which makes Enigma Jr more useful).