### PR TITLE
Fix loading saved applet data

### DIFF
--- a/software/o_c_REV/APP_HEMISPHERE.ino
+++ b/software/o_c_REV/APP_HEMISPHERE.ino
@@ -96,7 +96,11 @@ public:
         {
             int index = get_applet_index_by_id(values_[h]);
             SetApplet(h, index);
-            uint64_t data = (uint64_t(values_[8 + h]) << 48) + (uint64_t(values_[6 + h]) << 32) + (values_[4 + h] << 16) + values_[2 + h];
+            uint64_t data =
+                (uint64_t(values_[8 + h]) << 48) |
+                (uint64_t(values_[6 + h]) << 32) |
+                (uint64_t(values_[4 + h]) << 16) |
+                (uint64_t(values_[2 + h]));
             available_applets[index].OnDataReceive(h, data);
         }
         ClockSetup.OnDataReceive(0, uint64_t(values_[HEMISPHERE_CLOCK_DATA]));


### PR DESCRIPTION
I was getting unexpected results when storing/reloading some applet data (I noticed it in ShiftReg)
This seems to have corrected it - More explicit data casts, and bitwise OR rather than addition.