### PR TITLE
Internal Clock Enhancements

### DIFF
--- a/software/o_c_REV/HEM_Metronome.ino
+++ b/software/o_c_REV/HEM_Metronome.ino
@@ -34,9 +34,9 @@ public:
 
         // Outputs
         if (clock_m->IsRunning()) {
-            if (clock_m->Tock()) {
+            if (clock_m->Tock(hemisphere)) {
                 ClockOut(0);
-                if (clock_m->EndOfBeat()) ClockOut(1);
+                if (clock_m->EndOfBeat(hemisphere)) ClockOut(1);
             }
         }
     }
@@ -49,21 +49,14 @@ public:
     void OnButtonPress() { }
 
     void OnEncoderMove(int direction) {
-        uint16_t bpm = clock_m->GetTempo();
-        bpm += direction;
-        clock_m->SetTempoBPM(bpm);
+        clock_m->SetTempoBPM(clock_m->GetTempo() + direction);
     }
         
     uint64_t OnDataRequest() {
-        uint64_t data = 0;
-        Pack(data, PackLocation {0,16}, clock_m->GetTempo());
-        Pack(data, PackLocation {16,5}, clock_m->GetMultiply() - 1);
-        return data;
+        return 0;
     }
 
     void OnDataReceive(uint64_t data) {
-        clock_m->SetTempoBPM(Unpack(data, PackLocation {0,16}));
-        clock_m->SetMultiply(Unpack(data, PackLocation {16,5}) + 1);
     }
 
 protected:
@@ -77,7 +70,6 @@ protected:
     }
     
 private:
-    int cursor; // 0=Tempo, 1=Multiply, 2=Start/Stop
     ClockManager *clock_m = clock_m->get();
     
     void DrawInterface() {

--- a/software/o_c_REV/HSClockManager.h
+++ b/software/o_c_REV/HSClockManager.h
@@ -24,34 +24,45 @@
 #ifndef CLOCK_MANAGER_H
 #define CLOCK_MANAGER_H
 
-const uint16_t CLOCK_TEMPO_MIN = 10;
-const uint16_t CLOCK_TEMPO_MAX = 300;
+#define CLOCK_PPQN 4
+
+static constexpr uint16_t CLOCK_TEMPO_MIN = 10;
+static constexpr uint16_t CLOCK_TEMPO_MAX = 300;
+static constexpr uint32_t CLOCK_TICKS_MIN = 1000000 / CLOCK_TEMPO_MAX;
+static constexpr uint32_t CLOCK_TICKS_MAX = 1000000 / CLOCK_TEMPO_MIN;
+
+constexpr int MIDI_OUT_PPQN = 24;
+constexpr int CLOCK_MAX_MULTIPLE = 24;
+constexpr int CLOCK_MIN_MULTIPLE = -31; // becomes /32
 
 class ClockManager {
     static ClockManager *instance;
-    uint32_t ticks_per_tock; // Based on the selected tempo in BPM
-    uint32_t last_tock_tick; // The tick of the most recent tock
-    uint32_t last_tock_check; // To avoid checking the tock more than once per tick
-    bool tock; // The most recent tock value
+
+    enum ClockOutput {
+        LEFT_CLOCK,
+        RIGHT_CLOCK,
+        MIDI_CLOCK,
+        NR_OF_CLOCKS
+    };
+
     uint16_t tempo; // The set tempo, for display somewhere else
-    bool running; // Specifies whether the clock is running for interprocess communication
-    bool paused; // Specifies whethr the clock is paused
-    int8_t tocks_per_beat; // Multiplier
-    bool cycle; // Alternates for each tock, for display purposes
-    byte count; // Multiple counter
-    bool forwarded; // Master clock forwarding is enabled when true
+    uint32_t ticks_per_beat; // Based on the selected tempo in BPM
+    bool running = 0; // Specifies whether the clock is running for interprocess communication
+    bool paused = 0; // Specifies whethr the clock is paused
+    bool forwarded = 0; // Master clock forwarding is enabled when true
+
+    uint32_t clock_tick = 0; // tick when a physical clock was received on DIGITAL 1
+    uint32_t beat_tick = 0; // The tick to count from
+    bool tock[NR_OF_CLOCKS] = {0,0,0}; // The current tock value
+    int tocks_per_beat[NR_OF_CLOCKS] = {1, 1, MIDI_OUT_PPQN}; // Multiplier
+    int clock_ppqn = 4; // external clock multiple
+    bool cycle = 0; // Alternates for each tock, for display purposes
+    int count[NR_OF_CLOCKS] = {0,0,0}; // Multiple counter, 0 is a special case when first starting the clock
+
+    bool boop[4]; // Manual triggers
 
     ClockManager() {
         SetTempoBPM(120);
-        SetMultiply(1);
-        running = 0;
-        paused = 0;
-        cycle = 0;
-        last_tock_tick = 0;
-        last_tock_check = 0;
-        count = 0;
-        tock = 0;
-        forwarded = 0;
     }
 
 public:
@@ -60,9 +71,14 @@ public:
         return instance;
     }
 
-    void SetMultiply(int8_t multiply) {
-        multiply = constrain(multiply, 1, 24);
-        tocks_per_beat = multiply;
+    void SetMultiply(int multiply, bool ch = 0) {
+        multiply = constrain(multiply, CLOCK_MIN_MULTIPLE, CLOCK_MAX_MULTIPLE);
+        tocks_per_beat[ch] = multiply;
+    }
+
+    // adjusts the expected clock multiple for external clock pulses
+    void SetClockPPQN(int clkppqn) {
+        clock_ppqn = constrain(clkppqn, 0, 24);
     }
 
     /* Set ticks per tock, based on one million ticks per minute divided by beats per minute.
@@ -71,39 +87,121 @@ public:
      */
     void SetTempoBPM(uint16_t bpm) {
         bpm = constrain(bpm, CLOCK_TEMPO_MIN, CLOCK_TEMPO_MAX);
-        ticks_per_tock = 1000000 / bpm;
+        ticks_per_beat = 1000000 / bpm;
         tempo = bpm;
     }
 
-    int8_t GetMultiply() {return tocks_per_beat;}
+    int GetMultiply(bool ch = 0) {return tocks_per_beat[ch];}
+    int GetClockPPQN() { return clock_ppqn; }
 
     /* Gets the current tempo. This can be used between client processes, like two different
      * hemispheres.
      */
     uint16_t GetTempo() {return tempo;}
 
-    void Reset() {
-        last_tock_tick = OC::CORE::ticks;
-        count = 0;
+    // Resync multipliers, optionally skipping the first tock
+    void Reset(bool count_skip = 0) {
+        beat_tick = OC::CORE::ticks;
+        for (int ch = 0; ch < NR_OF_CLOCKS; ch++) {
+            if (tocks_per_beat[ch] > 0 || 0 == count_skip) count[ch] = count_skip;
+        }
         cycle = 1 - cycle;
     }
 
-    void Start() {
-        forwarded = 0;
+    // used to align the internal clock with incoming clock pulses
+    void Nudge(int diff) {
+        if (diff > 0) diff--;
+        if (diff < 0) diff++;
+        beat_tick += diff;
+    }
+
+    // called on every tick when clock is running, before all Controllers
+    void SyncTrig(bool clocked) {
+        uint32_t now = OC::CORE::ticks;
+
+        // Reset only when all multipliers have been met
+        bool reset = 1;
+
+        // count and calculate Tocks
+        for (int ch = 0; ch < NR_OF_CLOCKS; ch++) {
+            if (tocks_per_beat[ch] == 0) { // disabled
+                tock[ch] = 0; continue;
+            }
+
+            if (tocks_per_beat[ch] > 0) { // multiply
+                uint32_t next_tock_tick = beat_tick + count[ch]*ticks_per_beat / static_cast<uint32_t>(tocks_per_beat[ch]);
+                tock[ch] = now >= next_tock_tick;
+                if (tock[ch]) ++count[ch]; // increment multiplier counter
+
+                reset = reset && (count[ch] > tocks_per_beat[ch]); // multiplier has been exceeded
+            } else { // division: -1 becomes /2, -2 becomes /3, etc.
+                int div = 1 - tocks_per_beat[ch];
+                uint32_t next_beat = beat_tick + (count[ch] ? ticks_per_beat : 0);
+                bool beat_exceeded = (now > next_beat);
+                if (beat_exceeded) {
+                    ++count[ch];
+                    tock[ch] = (count[ch] % div) == 1;
+                }
+                else
+                    tock[ch] = 0;
+
+                // resync on every beat
+                reset = reset && beat_exceeded;
+                if (tock[ch]) count[ch] = 1;
+            }
+
+        }
+        if (reset) Reset(1); // skip the one we're already on
+
+        // handle syncing to physical clocks
+        if (clocked && clock_tick && clock_ppqn) {
+
+            uint32_t clock_diff = now - clock_tick;
+            if (clock_ppqn * clock_diff > CLOCK_TICKS_MAX) clock_tick = 0; // too slow, reset clock tracking
+
+            // if there is a previous clock tick, update tempo and sync
+            if (clock_tick && clock_diff) {
+                // update the tempo
+                ticks_per_beat = constrain(clock_ppqn * clock_diff, CLOCK_TICKS_MIN, CLOCK_TICKS_MAX); // time since last clock is new tempo
+                tempo = 1000000 / ticks_per_beat; // imprecise, for display purposes
+
+                int ticks_per_clock = ticks_per_beat / clock_ppqn; // rounded down
+
+                // time since last beat
+                int tick_offset = now - beat_tick;
+
+                // too long ago? time til next beat
+                if (tick_offset > ticks_per_clock / 2) tick_offset -= ticks_per_beat;
+
+                // within half a clock pulse of the nearest beat AND significantly large
+                if (abs(tick_offset) < ticks_per_clock / 2 && abs(tick_offset) > 4)
+                    Nudge(tick_offset); // nudge the beat towards us
+
+            }
+        }
+        // clock has been physically ticked
+        if (clocked) clock_tick = now;
+
+    }
+
+    void Start(bool p = 0) {
+        Reset();
         running = 1;
-        Unpause();
+        paused = p;
     }
 
     void Stop() {
         running = 0;
-        Unpause();
+        paused = 0;
     }
 
     void Pause() {paused = 1;}
 
-    void Unpause() {paused = 0;}
+    void ToggleForwarding() {
+        forwarded = 1 - forwarded;
+    }
 
-    void ToggleForwarding() {forwarded = 1 - forwarded;}
+    void SetForwarding(bool f) {forwarded = f;}
 
     bool IsRunning() {return (running && !paused);}
 
@@ -111,23 +209,31 @@ public:
 
     bool IsForwarded() {return forwarded;}
 
-    /* Returns true if the clock should fire on this tick, based on the current tempo */
-    bool Tock() {
-        uint32_t now = OC::CORE::ticks;
-        if (now != last_tock_check) {
-            last_tock_check = now;
-            if (now >= (last_tock_tick + (ticks_per_tock / static_cast<uint32_t>(tocks_per_beat)))) {
-                tock = 1;
-                last_tock_tick = now;
-                if (++count >= tocks_per_beat) Reset();
-            } else tock = 0;
+    // beep boop
+    void Boop(int ch = 0) {
+        boop[ch] = true;
+    }
+    bool Beep(int ch = 0) {
+        if (boop[ch]) {
+            boop[ch] = false;
+            return true;
         }
-        return tock;
+        return false;
     }
 
-    bool EndOfBeat() {return count == 0;}
+    /* Returns true if the clock should fire on this tick, based on the current tempo and multiplier */
+    bool Tock(int ch = 0) {
+        return tock[ch];
+    }
 
-    bool Cycle() {return cycle;}
+    // Returns true if MIDI Clock should be sent on this tick
+    bool MIDITock() {
+        return Tock(MIDI_CLOCK);
+    }
+
+    bool EndOfBeat(bool ch = 0) {return count[ch] == 1;}
+
+    bool Cycle(bool ch = 0) {return cycle;}
 };
 
 ClockManager *ClockManager::instance = 0;


### PR DESCRIPTION
This is a fairly elegant solution to #23 that's hopefully not too intrusive.

Clock Forwarding and internal clock Start/Stop are now independent settings. On the ClockSetup screen, turn encoder left to toggle Start/Stop, turn right to toggle Forwarding, indicated by a LINK_ICON. Long-press left encoder will still Pause/Unpause.
Internal clock always triggers Digital 1, will only trigger Digital 3 if forwarding is ON.

Functionally, I think it's exactly what I wanted. Open to feedback on the interface screen.