### PR TITLE
Add OC_strings to DualQuant in case enigma app is disabled. Fix #38

### DIFF
--- a/software/o_c_REV/APP_ENIGMA.ino
+++ b/software/o_c_REV/APP_ENIGMA.ino
@@ -20,7 +20,6 @@
 
 #ifdef ENABLE_APP_ENIGMA
 
-#include "OC_strings.h"
 #include "HSApplication.h"
 #include "HSMIDI.h"
 #include "enigma/TuringMachine.h"

--- a/software/o_c_REV/OC_ui.cpp
+++ b/software/o_c_REV/OC_ui.cpp
@@ -8,7 +8,6 @@
 #include "OC_core.h"
 #include "OC_gpio.h"
 #include "OC_menus.h"
-#include "OC_strings.h"
 #include "OC_ui.h"
 #include "OC_version.h"
 #include "OC_options.h"

--- a/software/o_c_REV/o_c_REV.ino
+++ b/software/o_c_REV/o_c_REV.ino
@@ -34,6 +34,7 @@
 #include "OC_calibration.h"
 #include "OC_digital_inputs.h"
 #include "OC_menus.h"
+#include "OC_strings.h"
 #include "OC_ui.h"
 #include "OC_version.h"
 #include "OC_options.h"


### PR DESCRIPTION
As mentioned on #38, disabling the enigma app causes a compilation error because DualQuant is missing the `#include "OC_strings.h"`.