### PR TITLE
Display encoder direction config on Calibration screen

### DIFF
--- a/software/o_c_REV/OC_calibration.ino
+++ b/software/o_c_REV/OC_calibration.ino
@@ -521,6 +521,14 @@ void calibration_draw(const CalibrationState &state) {
   graphics.setPrintPos(menu::kIndentDx, y + 2);
   if (step->help)
     graphics.print(step->help);
+ 
+  // NJM: display encoder direction config on first and last screens
+  if (step->step == HELLO || step->step == CALIBRATION_EXIT) {
+      y += menu::kMenuLineH;
+      graphics.setPrintPos(menu::kIndentDx, y + 2);
+      graphics.print("Encoders: ");
+      graphics.print(OC::Strings::encoder_config_strings[ OC::calibration_data.encoder_config() ]);
+  }
 
   weegfx::coord_t x = menu::kDisplayWidth - 22;
   y = 2;


### PR DESCRIPTION
Resolves #52 

Actual encoder config setting is shown on the first calibration screen, and again on the last page before you save it.