### PR TITLE
Basic PlatformIO build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ software/o_c_REV/.DS_Store
 shelved/
 Hemisphere\ Suite.cpp
 builds
+.pio

--- a/software/o_c_REV/extern/stmlib_utils_random.cpp
+++ b/software/o_c_REV/extern/stmlib_utils_random.cpp
@@ -27,7 +27,7 @@
 // Random number generator.
 
 // #include "stmlib/utils/random.h"
-#include "utils/stmlib_utils_random.h"
+#include "stmlib_utils_random.h"
 
 namespace stmlib {
 

--- a/software/o_c_REV/extern/stmlib_utils_random.h
+++ b/software/o_c_REV/extern/stmlib_utils_random.h
@@ -31,6 +31,7 @@
 
 // #include "stmlib/stmlib.h"
 #include <stdint.h>
+#include "util/util_macros.h"
 
 namespace stmlib {
 

--- a/software/o_c_REV/platformio.ini
+++ b/software/o_c_REV/platformio.ini
@@ -1,0 +1,28 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter, extra scripting
+;   Upload options: custom port, speed and extra flags
+;   Library options: dependencies, extra library storages
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+default_envs = oc_prod
+
+[env]
+platform = teensy@1.6.0
+framework = arduino
+board = teensy31
+board_build.f_cpu = 120000000
+lib_deps = EEPROM
+build_flags =
+  -DTEENSY_OPT_FASTER
+  -DUSB_MIDI -UUSB_SERIAL
+
+[env:oc_prod]
+build_flags = ${env.build_flags}
+
+[env:oc_dev]
+build_flags = ${env.build_flags} -DOC_DEV
+; -DPRINT_DEBUG

--- a/software/o_c_REV/platformio.ini
+++ b/software/o_c_REV/platformio.ini
@@ -11,14 +11,16 @@ src_dir = .
 default_envs = oc_prod
 
 [env]
-platform = teensy@1.6.0
+platform = teensy@4.17.0
 framework = arduino
 board = teensy31
 board_build.f_cpu = 120000000
 lib_deps = EEPROM
 build_flags =
-  -DTEENSY_OPT_FASTER
-  -DUSB_MIDI -UUSB_SERIAL
+  -DTEENSY_OPT_SMALLEST_CODE
+  -DUSB_MIDI
+
+upload_protocol = teensy-gui
 
 [env:oc_prod]
 build_flags = ${env.build_flags}


### PR DESCRIPTION
I've staged this patch (per @recliq #54 ) for convenient testing and cherry-picking for other forks. It is enough to get the branch to build with Platform IO. It works via PIO inside VSCode, as well as with the PlatformIO CLI on my Raspberry Pi.

The built binary size is greatly reduced:
```
RAM:   [=======   ]  73.4% (used 48100 bytes from 65536 bytes)
Flash: [=======   ]  67.8% (used 177816 bytes from 262144 bytes)
```

Maybe teensy@1.6.0 within PIO has less overhead or something? It also builds with teensy@3.7.1 but yields a binary size similar to what we're used to. `-DTEENSY_OPT_SMALLEST_CODE` yields a smaller binary... but at what expense? Trying with teensy@4.0+ gives me stupid errors.

Anyway, I've been actively using this build config and haven't encountered any major runtime issues yet... I even re-enabled all the MIDI stuff and it still fits! Needs more testing for sure...