### PR TITLE
Stock O&C apps

### DIFF
--- a/software/o_c_REV/APP_CHORDS.ino
+++ b/software/o_c_REV/APP_CHORDS.ino
@@ -26,6 +26,8 @@
 // from Braids by Olivier Gillet (see braids_quantizer.h/cc et al.). It has since
 // grown a little bit...
 
+#ifdef ENABLE_APP_CHORDS
+
 #include "OC_apps.h"
 #include "util/util_settings.h"
 #include "util/util_trigger_delay.h"
@@ -1393,3 +1395,5 @@ void CHORDS_screensaver() {
   graphics.printf("%u",  us);
 #endif
 }
+
+#endif // ENABLE_APP_CHORDS

--- a/software/o_c_REV/APP_CHORDS.ino
+++ b/software/o_c_REV/APP_CHORDS.ino
@@ -1,0 +1,1395 @@
+// Copyright (c) 2015, 2016, 2017 Patrick Dowling, Tim Churches, Max Stadler
+//
+// Initial app implementation: Patrick Dowling (pld@gurkenkiste.com)
+// Modifications by: Tim Churches (tim.churches@gmail.com)
+// Yet more Modifications by: mxmxmx
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Quad quantizer app, based around the the quantizer/scales implementation from
+// from Braids by Olivier Gillet (see braids_quantizer.h/cc et al.). It has since
+// grown a little bit...
+
+#include "OC_apps.h"
+#include "util/util_settings.h"
+#include "util/util_trigger_delay.h"
+#include "braids_quantizer.h"
+#include "braids_quantizer_scales.h"
+#include "OC_menus.h"
+#include "OC_scales.h"
+#include "OC_scale_edit.h"
+#include "OC_strings.h"
+#include "OC_chords.h"
+#include "OC_chords_edit.h"
+#include "OC_input_map.h"
+#include "OC_input_maps.h"
+
+enum CHORDS_SETTINGS {
+  CHORDS_SETTING_SCALE,
+  CHORDS_SETTING_ROOT,
+  CHORDS_SETTING_PROGRESSION,
+  CHORDS_SETTING_MASK,
+  CHORDS_SETTING_CV_SOURCE,
+  CHORDS_SETTING_CHORDS_ADVANCE_TRIGGER_SOURCE,
+  CHORDS_SETTING_PLAYMODES,
+  CHORDS_SETTING_DIRECTION,
+  CHORDS_SETTING_BROWNIAN_PROBABILITY,
+  CHORDS_SETTING_TRIGGER_DELAY,
+  CHORDS_SETTING_TRANSPOSE,
+  CHORDS_SETTING_OCTAVE,
+  CHORDS_SETTING_CHORD_SLOT,
+  CHORDS_SETTING_NUM_CHORDS_0,
+  CHORDS_SETTING_NUM_CHORDS_1,
+  CHORDS_SETTING_NUM_CHORDS_2,
+  CHORDS_SETTING_NUM_CHORDS_3,
+  CHORDS_SETTING_CHORD_EDIT,
+  // CV sources
+  CHORDS_SETTING_ROOT_CV,
+  CHORDS_SETTING_MASK_CV,
+  CHORDS_SETTING_TRANSPOSE_CV,
+  CHORDS_SETTING_OCTAVE_CV,
+  CHORDS_SETTING_QUALITY_CV,
+  CHORDS_SETTING_VOICING_CV,
+  CHORDS_SETTING_INVERSION_CV,
+  CHORDS_SETTING_PROGRESSION_CV,
+  CHORDS_SETTING_DIRECTION_CV,
+  CHORDS_SETTING_BROWNIAN_CV,
+  CHORDS_SETTING_NUM_CHORDS_CV,
+  CHORDS_SETTING_DUMMY,
+  CHORDS_SETTING_MORE_DUMMY,
+  CHORDS_SETTING_LAST
+};
+
+enum CHORDS_CV_SOURCES {
+  CHORDS_CV_SOURCE_CV1,
+  CHORDS_CV_SOURCE_CV2,
+  CHORDS_CV_SOURCE_CV3,
+  CHORDS_CV_SOURCE_CV4,
+  CHORDS_CV_SOURCE_LAST
+};
+
+enum CHORDS_ADVANCE_TRIGGER_SOURCE {
+  CHORDS_ADVANCE_TRIGGER_SOURCE_TR1,
+  CHORDS_ADVANCE_TRIGGER_SOURCE_TR2,
+  CHORDS_ADVANCE_TRIGGER_SOURCE_LAST
+};
+
+enum CHORDS_CV_DESTINATIONS {
+  CHORDS_CV_DEST_NONE,
+  CHORDS_CV_DEST_ROOT,
+  CHORDS_CV_DEST_OCTAVE,
+  CHORDS_CV_DEST_TRANSPOSE,
+  CHORDS_CV_DEST_MASK,
+  CHORDS_CV_DEST_LAST
+};
+
+// enum MENU_PAGES {
+//   PARAMETERS,
+//   CV_MAPPING
+// };
+
+enum CHORDS_MENU_PAGES {
+  MENU_PARAMETERS,
+  MENU_CV_MAPPING,
+  MENU_PAGES_LAST
+};
+
+enum CHORDS_PLAYMODES {
+  _NONE,
+  _SEQ1,
+  _SEQ2,
+  _SEQ3,
+  _TR1,
+  _TR2,
+  _TR3,
+  _SH1,
+  _SH2,
+  _SH3,
+  _SH4,
+  _CV1,
+  _CV2,
+  _CV3,
+  _CV4,
+  CHORDS_PLAYMODES_LAST
+};
+
+enum CHORDS_DIRECTIONS {
+  CHORDS_FORWARD,
+  CHORDS_REVERSE,
+  CHORDS_PENDULUM1,
+  CHORDS_PENDULUM2,
+  CHORDS_RANDOM,
+  CHORDS_BROWNIAN,
+  CHORDS_DIRECTIONS_LAST
+};
+
+#define DUMMY2 0
+extern uint_fast8_t MENU_REDRAW;
+
+class Chords : public settings::SettingsBase<Chords, CHORDS_SETTING_LAST> {
+public:
+
+  int get_scale(uint8_t selected_scale_slot_) const {
+    return values_[CHORDS_SETTING_SCALE];
+  }
+
+  void set_scale(int scale) {
+
+    if (scale != get_scale(DUMMY2)) {
+      const OC::Scale &scale_def = OC::Scales::GetScale(scale);
+      uint16_t mask = get_mask();
+      if (0 == (mask & ~(0xffff << scale_def.num_notes)))
+        mask |= 0x1;
+      apply_value(CHORDS_SETTING_MASK, mask);
+      apply_value(CHORDS_SETTING_SCALE, scale);
+    }
+  }
+
+  // dummy
+  int get_scale_select() const {
+    return 0;
+  }
+
+  // dummy
+  void set_scale_at_slot(int scale, uint16_t mask, int root, int transpose, uint8_t scale_slot) {
+
+  }
+
+  // dummy
+  int get_transpose(uint8_t DUMMY) const {
+    return 0;
+  }
+
+  bool octave_toggle() {
+    _octave_toggle = (~_octave_toggle) & 1u;
+    return _octave_toggle;
+  }
+
+  bool poke_octave_toggle() const {
+    return _octave_toggle;
+  }
+
+  int get_progression() const {
+    return values_[CHORDS_SETTING_PROGRESSION];
+  }
+
+  int get_progression_cv() const {
+    return values_[CHORDS_SETTING_PROGRESSION_CV];
+  }
+
+  int get_active_progression() const {
+    return active_progression_;
+  }
+
+  int get_chord_slot() const {
+    return values_[CHORDS_SETTING_CHORD_SLOT];
+  }
+
+  void set_chord_slot(int8_t slot) {
+    apply_value(CHORDS_SETTING_CHORD_SLOT, slot);
+  }
+
+  int get_num_chords(uint8_t progression) const {
+
+     int len = 0x0;
+     switch (progression) {
+
+        case 0:
+          len = values_[CHORDS_SETTING_NUM_CHORDS_0];
+        break;
+        case 1:
+          len = values_[CHORDS_SETTING_NUM_CHORDS_1];
+        break;
+        case 2:
+          len = values_[CHORDS_SETTING_NUM_CHORDS_2];
+        break;
+        case 3:
+          len =  values_[CHORDS_SETTING_NUM_CHORDS_3];
+        break;
+        default:
+        break;
+    }
+    return len;
+  }
+
+  void set_num_chords(int8_t num_chords, uint8_t progression) {
+
+    // set progression length:
+    switch (progression) {
+      case 0:
+      apply_value(CHORDS_SETTING_NUM_CHORDS_0, num_chords);
+      break;
+      case 1:
+      apply_value(CHORDS_SETTING_NUM_CHORDS_1, num_chords);
+      break;
+      case 2:
+      apply_value(CHORDS_SETTING_NUM_CHORDS_2, num_chords);
+      break;
+      case 3:
+      apply_value(CHORDS_SETTING_NUM_CHORDS_3, num_chords);
+      break;
+      default:
+      break;
+    }
+  }
+
+  int get_num_chords_cv() const {
+    return values_[CHORDS_SETTING_NUM_CHORDS_CV];
+  }
+
+  int active_chord() const {
+    return active_chord_;
+  }
+
+  int get_playmode() const {
+    return values_[CHORDS_SETTING_PLAYMODES];
+  }
+
+  int get_direction() const {
+    return values_[CHORDS_SETTING_DIRECTION];
+  }
+
+  uint8_t get_direction_cv() const {
+    return values_[CHORDS_SETTING_DIRECTION_CV];
+  }
+
+  uint8_t get_brownian_probability() const {
+    return values_[CHORDS_SETTING_BROWNIAN_PROBABILITY];
+  }
+
+  int8_t get_brownian_probability_cv() const {
+    return values_[CHORDS_SETTING_BROWNIAN_CV];
+  }
+
+  int get_root() const {
+    return values_[CHORDS_SETTING_ROOT];
+  }
+
+  int get_root(uint8_t DUMMY) const {
+    return 0x0;
+  }
+
+  uint8_t get_root_cv() const {
+    return values_[CHORDS_SETTING_ROOT_CV];
+  }
+
+  int get_display_num_chords() const {
+    return display_num_chords_;
+  }
+
+  uint16_t get_mask() const {
+    return values_[CHORDS_SETTING_MASK];
+  }
+
+  uint16_t get_rotated_mask() const {
+    return last_mask_;
+  }
+
+  uint8_t get_mask_cv() const {
+    return values_[CHORDS_SETTING_MASK_CV];
+  }
+
+  int16_t get_cv_source() const {
+    return values_[CHORDS_SETTING_CV_SOURCE];
+  }
+
+  int8_t get_chords_trigger_source() const {
+    return values_[CHORDS_SETTING_CHORDS_ADVANCE_TRIGGER_SOURCE];
+  }
+
+  uint16_t get_trigger_delay() const {
+    return values_[CHORDS_SETTING_TRIGGER_DELAY];
+  }
+
+  int get_transpose() const {
+    return values_[CHORDS_SETTING_TRANSPOSE];
+  }
+
+  uint8_t get_transpose_cv() const {
+    return values_[CHORDS_SETTING_TRANSPOSE_CV];
+  }
+
+  int get_octave() const {
+    return values_[CHORDS_SETTING_OCTAVE];
+  }
+
+  uint8_t get_octave_cv() const {
+    return values_[CHORDS_SETTING_OCTAVE_CV];
+  }
+
+  uint8_t get_quality_cv() const {
+    return values_[CHORDS_SETTING_QUALITY_CV];
+  }
+
+  uint8_t get_inversion_cv() const {
+    return values_[CHORDS_SETTING_INVERSION_CV];
+  }
+
+  uint8_t get_voicing_cv() const {
+    return values_[CHORDS_SETTING_VOICING_CV];
+  }
+
+  uint8_t clockState() const {
+    return clock_display_.getState();
+  }
+
+  uint8_t get_menu_page() const {
+    return menu_page_;
+  }
+
+  void set_menu_page(uint8_t _menu_page) {
+    menu_page_ = _menu_page;
+  }
+
+  void update_inputmap(int num_slots, uint8_t range) {
+    input_map_.Configure(OC::InputMaps::GetInputMap(num_slots), range);
+  }
+
+  void clear_CV_mapping() {
+    // clear all ...
+    apply_value(CHORDS_SETTING_ROOT_CV, 0);
+    apply_value(CHORDS_SETTING_MASK_CV, 0);
+    apply_value(CHORDS_SETTING_TRANSPOSE_CV, 0);
+    apply_value(CHORDS_SETTING_OCTAVE_CV, 0);
+    apply_value(CHORDS_SETTING_QUALITY_CV, 0);
+    apply_value(CHORDS_SETTING_VOICING_CV, 0);
+    apply_value(CHORDS_SETTING_INVERSION_CV, 0);
+    apply_value(CHORDS_SETTING_BROWNIAN_CV, 0);
+    apply_value(CHORDS_SETTING_DIRECTION_CV, 0);
+    apply_value(CHORDS_SETTING_PROGRESSION_CV, 0);
+    apply_value(CHORDS_SETTING_NUM_CHORDS_CV, 0);
+  }
+
+  void Init() {
+
+    InitDefaults();
+    menu_page_ = MENU_PARAMETERS;
+    apply_value(CHORDS_SETTING_CV_SOURCE, 0x0);
+    set_scale(OC::Scales::SCALE_SEMI);
+    force_update_ = true;
+    _octave_toggle = false;
+    last_scale_= -1;
+    last_mask_ = 0;
+    last_sample_ = 0;
+    chord_advance_last_ = true;
+    progression_advance_last_ = true;
+    active_chord_ = 0;
+    chord_repeat_ = false;
+    progression_cnt_ = 0;
+    active_progression_ = 0;
+    playmode_last_ = 0;
+    progression_last_ = 0;
+    progression_EoP_ = 0;
+    num_chords_last_ = 0;
+    chords_direction_ = true;
+    display_num_chords_ = 0x1;
+
+    trigger_delay_.Init();
+    input_map_.Init();
+    quantizer_.Init();
+    chords_.Init();
+    update_scale(true, false);
+    clock_display_.Init();
+    update_enabled_settings();
+  }
+
+  void force_update() {
+    //force_update_ = true;
+  }
+
+  int8_t _clock(uint8_t sequence_length, uint8_t sequence_count, uint8_t sequence_max, bool _reset) {
+
+        int8_t EoP = 0x0, _clk_cnt, _direction;
+        bool reset = !digitalReadFast(TR4) | _reset;
+
+        _clk_cnt = active_chord_;
+        _direction = get_direction();
+
+        if (get_direction_cv()) {
+           _direction += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_direction_cv() - 1)) + 255) >> 9;
+           CONSTRAIN(_direction, 0, CHORDS_DIRECTIONS_LAST - 0x1);
+        }
+
+        switch (_direction) {
+
+          case CHORDS_FORWARD:
+          {
+            _clk_cnt++;
+            if (reset)
+              _clk_cnt = 0x0;
+            // end of sequence?
+            else if (_clk_cnt > sequence_length)
+              _clk_cnt = 0x0;
+            else if (_clk_cnt == sequence_length)
+               EoP = 0x1;
+          }
+          break;
+          case CHORDS_REVERSE:
+          {
+            _clk_cnt--;
+            if (reset)
+              _clk_cnt = sequence_length;
+            // end of sequence?
+            else if (_clk_cnt < 0)
+              _clk_cnt = sequence_length;
+            else if (!_clk_cnt)
+               EoP = 0x1;
+          }
+          break;
+          case CHORDS_PENDULUM1:
+          case CHORDS_BROWNIAN:
+          if (CHORDS_BROWNIAN == get_direction()) {
+            // Compare Brownian probability and reverse direction if needed
+            int16_t brown_prb = get_brownian_probability();
+
+            if (get_brownian_probability_cv()) {
+              brown_prb += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_brownian_probability_cv() - 1)) + 8) >> 3;
+              CONSTRAIN(brown_prb, 0, 256);
+            }
+            if (random(0,256) < brown_prb)
+              chords_direction_ = !chords_direction_;
+          }
+          {
+            if (chords_direction_) {
+              _clk_cnt++;
+              if (reset)
+                _clk_cnt = 0x0;
+              else if (_clk_cnt >= sequence_length) {
+
+                if (sequence_count >= sequence_max) {
+                  chords_direction_ = false;
+                  _clk_cnt = sequence_length;
+                }
+                else EoP = 0x1;
+              }
+            }
+            // reverse direction:
+            else {
+              _clk_cnt--;
+              if (reset)
+                _clk_cnt = sequence_length;
+              else if (_clk_cnt <= 0) {
+                // end of sequence ?
+                if (sequence_count == 0x0) {
+                  chords_direction_ = true;
+                  _clk_cnt = 0x0;
+                }
+                else EoP = -0x1;
+              }
+            }
+          }
+          break;
+          case CHORDS_PENDULUM2:
+          {
+            if (chords_direction_) {
+
+              if (!chord_repeat_)
+                _clk_cnt++;
+              chord_repeat_ = false;
+
+              if (reset)
+                _clk_cnt = 0x0;
+              else if (_clk_cnt >= sequence_length) {
+                // end of sequence ?
+                if (sequence_count >= sequence_max) {
+                  chords_direction_ = false;
+                  _clk_cnt = sequence_length;
+                  chord_repeat_ = true; // repeat last step
+                }
+                else EoP = 0x1;
+              }
+            }
+            // reverse direction:
+            else {
+
+              if (!chord_repeat_)
+                _clk_cnt--;
+              chord_repeat_ = false;
+
+              if (reset)
+                _clk_cnt = sequence_length;
+              else if (_clk_cnt <= 0x0) {
+                // end of sequence ?
+                if (sequence_count == 0x0) {
+                  chords_direction_ = true;
+                  _clk_cnt = 0x0;
+                  chord_repeat_ = true; // repeat first step
+                }
+                else EoP = -0x1;
+              }
+            }
+          }
+          break;
+          case CHORDS_RANDOM:
+          _clk_cnt = random(sequence_length + 0x1);
+          if (reset)
+            _clk_cnt = 0x0;
+          // jump to next sequence if we happen to hit the last note:
+          else if (_clk_cnt >= sequence_length)
+            EoP = random(0x2);
+          break;
+          default:
+          break;
+        }
+        active_chord_ = _clk_cnt;
+        return EoP;
+  }
+
+
+  inline void Update(uint32_t triggers) {
+
+    bool triggered = triggers & DIGITAL_INPUT_MASK(0x0);
+
+    trigger_delay_.Update();
+    if (triggered)
+      trigger_delay_.Push(OC::trigger_delay_ticks[get_trigger_delay()]);
+    triggered = trigger_delay_.triggered();
+
+    int32_t sample_a = last_sample_;
+    int32_t temp_sample = 0;
+
+    if (triggered) {
+
+      int32_t pitch, cv_source, transpose, octave, root, mask_rotate;
+      int8_t num_progression, num_progression_cv, num_chords, num_chords_cv, progression_max, progression_cnt, playmode, reset;
+
+      cv_source = get_cv_source();
+      transpose = get_transpose();
+      octave = get_octave();
+      root = get_root();
+      num_progression = get_progression();
+      progression_max = 0;
+      progression_cnt = 0;
+      num_progression_cv = 0;
+      num_chords = 0;
+      num_chords_cv = 0;
+      reset = 0;
+      mask_rotate = 0;
+      playmode = get_playmode();
+
+      // update mask?
+      if (get_mask_cv()) {
+        mask_rotate = (OC::ADC::value(static_cast<ADC_CHANNEL>(get_mask_cv() - 0x1)) + 127) >> 8;
+      }
+
+      update_scale(force_update_, mask_rotate);
+
+      if (num_progression != progression_last_ || playmode != playmode_last_) {
+        // reset progression:
+        progression_cnt_ = 0x0;
+        active_progression_ = num_progression;
+      }
+      playmode_last_ = playmode;
+      progression_last_ = num_progression;
+
+      if (get_progression_cv()) {
+        num_progression_cv = num_progression += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_progression_cv() - 1)) + 255) >> 9;
+        CONSTRAIN(num_progression, 0, OC::Chords::NUM_CHORD_PROGRESSIONS - 0x1);
+      }
+
+      if (get_num_chords_cv())
+        num_chords_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(get_num_chords_cv() - 1)) + 255) >> 9;
+
+      switch (playmode) {
+
+          case _NONE:
+            active_progression_ = num_progression;
+          break;
+          case _SEQ1:
+          case _SEQ2:
+          case _SEQ3:
+          {
+              progression_max = playmode;
+
+              if (progression_EoP_) {
+
+                // increment progression #
+                progression_cnt_ += progression_EoP_;
+                // reset progression #
+                progression_cnt_ = progression_cnt_ > progression_max ? 0x0 : progression_cnt_;
+                // update progression
+                active_progression_ = num_progression + progression_cnt_;
+                // wrap around:
+                if (active_progression_ >= OC::Chords::NUM_CHORD_PROGRESSIONS)
+                    active_progression_ -= OC::Chords::NUM_CHORD_PROGRESSIONS;
+                // reset
+                _clock(get_num_chords(active_progression_), 0x0, progression_max, true);
+                reset = true;
+              }
+              else if (num_progression_cv)  {
+                active_progression_ += num_progression_cv;
+                CONSTRAIN(active_progression_, 0, OC::Chords::NUM_CHORD_PROGRESSIONS - 0x1);
+              }
+              progression_cnt = progression_cnt_;
+          }
+          break;
+          case _TR1:
+          case _TR2:
+          case _TR3:
+          {
+            // get trigger
+            uint8_t _progression_advance_trig = digitalReadFast(TR3);
+            progression_max = playmode - _SEQ3;
+
+            if (_progression_advance_trig  < progression_advance_last_) {
+              // increment progression #
+              progression_cnt_++;
+              // reset progression #
+              progression_cnt_ = progression_cnt_ > progression_max ? 0x0 : progression_cnt_;
+              // update progression
+              active_progression_ = num_progression + progression_cnt_;
+              // + reset
+              reset = true;
+              // wrap around:
+              if (active_progression_ >= OC::Chords::NUM_CHORD_PROGRESSIONS)
+                  active_progression_ -= OC::Chords::NUM_CHORD_PROGRESSIONS;
+            }
+            else if (num_progression_cv)  {
+                active_progression_ += num_progression_cv;
+                CONSTRAIN(active_progression_, 0, OC::Chords::NUM_CHORD_PROGRESSIONS - 0x1);
+            }
+            progression_advance_last_ = _progression_advance_trig;
+            progression_max = 0x0;
+          }
+          break;
+          case _SH1:
+          case _SH2:
+          case _SH3:
+          case _SH4:
+          {
+             // SH?
+             uint8_t _progression_advance_trig = digitalReadFast(TR3);
+             if (_progression_advance_trig  < progression_advance_last_) {
+
+               num_chords = get_num_chords(num_progression) + num_chords_cv;
+               if (num_chords_cv)
+                  CONSTRAIN(num_chords, 0, OC::Chords::NUM_CHORDS - 0x1);
+               // length changed?
+               if (num_chords_last_ != num_chords)
+                  update_inputmap(num_chords + 0x1, 0x0);
+               // store values:
+               num_chords_last_ = num_chords;
+               active_progression_ = num_progression;
+               // process input:
+               active_chord_ = input_map_.Process(OC::ADC::value(static_cast<ADC_CHANNEL>(playmode - _SH1)));
+             }
+             progression_advance_last_ = _progression_advance_trig;
+          }
+          break;
+          case _CV1:
+          case _CV2:
+          case _CV3:
+          case _CV4:
+          {
+             num_chords = get_num_chords(num_progression) + num_chords_cv;
+             if (num_chords_cv)
+                CONSTRAIN(num_chords, 0, OC::Chords::NUM_CHORDS - 0x1);
+             // length changed ?
+             if (num_chords_last_ != num_chords)
+                update_inputmap(num_chords + 0x1, 0x0);
+             // store values:
+             num_chords_last_ = num_chords;
+             active_progression_ = num_progression;
+             // process input:
+             active_chord_ = input_map_.Process(OC::ADC::value(static_cast<ADC_CHANNEL>(playmode - _CV1)));
+          }
+          break;
+          default:
+          break;
+      }
+
+      num_progression = active_progression_;
+
+      if (playmode < _SH1) {
+        // next chord via trigger?
+        uint8_t _advance_trig = get_chords_trigger_source();
+
+        if (_advance_trig == CHORDS_ADVANCE_TRIGGER_SOURCE_TR2)
+          _advance_trig = digitalReadFast(TR2);
+        else if (triggered) {
+          _advance_trig = 0x0;
+          chord_advance_last_ = 0x1;
+        }
+
+        num_chords = get_num_chords(num_progression) + num_chords_cv;
+        if (num_chords_cv)
+            CONSTRAIN(num_chords, 0, OC::Chords::NUM_CHORDS - 0x1);
+
+        CONSTRAIN(active_chord_, 0x0, num_chords);
+
+        if (num_chords && (_advance_trig < chord_advance_last_))
+          progression_EoP_ = _clock(num_chords, progression_cnt, progression_max, reset);
+        chord_advance_last_ = _advance_trig;
+      }
+
+      display_num_chords_ = num_chords;
+      // active chord:
+      OC::Chord *active_chord = &OC::user_chords[active_chord_ + num_progression * OC::Chords::NUM_CHORDS];
+
+      int8_t _base_note = active_chord->base_note;
+      int8_t _octave = active_chord->octave;
+      int8_t _quality = active_chord->quality;
+      int8_t _voicing = active_chord->voicing;
+      int8_t _inversion = active_chord->inversion;
+
+      octave += _octave;
+      CONSTRAIN(octave, -6, 6);
+
+      if (_base_note) {
+        /*
+        *  we don't use the incoming CV pitch value — limit to valid base notes.
+        */
+        int8_t _limit = OC::Scales::GetScale(get_scale(DUMMY2)).num_notes;
+        _base_note = _base_note > _limit ? _limit : _base_note;
+        pitch = 0x0;
+        transpose += (_base_note - 0x1);
+      }
+      else {
+        pitch = quantizer_.enabled()
+                  ? OC::ADC::raw_pitch_value(static_cast<ADC_CHANNEL>(cv_source))
+                  : OC::ADC::pitch_value(static_cast<ADC_CHANNEL>(cv_source));
+      }
+
+      switch (cv_source) {
+
+        case CHORDS_CV_SOURCE_CV1:
+        break;
+        // todo
+        default:
+        break;
+      }
+
+    // S/H mode
+      if (get_root_cv()) {
+          root += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_root_cv() - 1)) + 127) >> 8;
+          CONSTRAIN(root, 0, 15);
+      }
+
+      if (get_octave_cv()) {
+        octave += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_octave_cv() - 1)) + 255) >> 9;
+        CONSTRAIN(octave, -4, 4);
+      }
+
+      if (get_transpose_cv()) {
+        transpose += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_transpose_cv() - 1)) + 63) >> 7;
+        CONSTRAIN(transpose, -15, 15);
+      }
+
+      if (get_quality_cv()) {
+        _quality += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_quality_cv() - 1)) + 255) >> 9;
+        CONSTRAIN(_quality, 0,  OC::Chords::CHORDS_QUALITY_LAST - 1);
+      }
+
+      if (get_inversion_cv()) {
+        _inversion += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_inversion_cv() - 1)) + 511) >> 10;
+        CONSTRAIN(_inversion, 0,  OC::Chords::CHORDS_INVERSION_LAST - 1);
+      }
+
+      if (get_voicing_cv()) {
+        _voicing += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_voicing_cv() - 1)) + 255) >> 9;
+        CONSTRAIN(_voicing, 0,  OC::Chords::CHORDS_VOICING_LAST - 1);
+      }
+
+      int32_t quantized = quantizer_.Process(pitch, root << 7, transpose);
+      // main sample, S/H:
+      sample_a = temp_sample = OC::DAC::pitch_to_scaled_voltage_dac(DAC_CHANNEL_A, quantized, octave + OC::inversion[_inversion][0], OC::DAC::get_voltage_scaling(DAC_CHANNEL_A));
+
+      // now derive chords ...
+      transpose += OC::qualities[_quality][1];
+      int32_t sample_b  = quantizer_.Process(pitch, root << 7, transpose);
+      transpose += OC::qualities[_quality][2];
+      int32_t sample_c  = quantizer_.Process(pitch, root << 7, transpose);
+      transpose += OC::qualities[_quality][3];
+      int32_t sample_d  = quantizer_.Process(pitch, root << 7, transpose);
+
+      //todo voicing for root note
+      sample_b = OC::DAC::pitch_to_scaled_voltage_dac(DAC_CHANNEL_B, sample_b, octave + OC::voicing[_voicing][1] + OC::inversion[_inversion][1], OC::DAC::get_voltage_scaling(DAC_CHANNEL_B));
+      sample_c = OC::DAC::pitch_to_scaled_voltage_dac(DAC_CHANNEL_C, sample_c, octave + OC::voicing[_voicing][2] + OC::inversion[_inversion][2], OC::DAC::get_voltage_scaling(DAC_CHANNEL_C));
+      sample_d = OC::DAC::pitch_to_scaled_voltage_dac(DAC_CHANNEL_D, sample_d, octave + OC::voicing[_voicing][3] + OC::inversion[_inversion][3], OC::DAC::get_voltage_scaling(DAC_CHANNEL_D));
+
+      OC::DAC::set<DAC_CHANNEL_A>(sample_a);
+      OC::DAC::set<DAC_CHANNEL_B>(sample_b);
+      OC::DAC::set<DAC_CHANNEL_C>(sample_c);
+      OC::DAC::set<DAC_CHANNEL_D>(sample_d);
+    }
+
+    bool changed = (last_sample_ != sample_a);
+
+    if (changed) {
+      MENU_REDRAW = 1;
+      last_sample_ = sample_a;
+    }
+
+    if (triggered) {
+      clock_display_.Update(1, true);
+    } else {
+      clock_display_.Update(1, false);
+    }
+  }
+
+  // Wrappers for ScaleEdit
+  void scale_changed() {
+    force_update_ = true;
+  }
+
+  uint16_t get_scale_mask(uint8_t scale_select) const {
+    return get_mask();
+  }
+
+  void update_scale_mask(uint16_t mask, uint8_t scale_select) {
+    apply_value(CHORDS_SETTING_MASK, mask);
+    last_mask_ = mask;
+    force_update_ = true;
+  }
+
+  // Maintain an internal list of currently available settings, since some are
+  // dependent on others. It's kind of brute force, but eh, works :) If other
+  // apps have a similar need, it can be moved to a common wrapper
+
+  int num_enabled_settings() const {
+    return num_enabled_settings_;
+  }
+
+  CHORDS_SETTINGS enabled_setting_at(int index) const {
+    return enabled_settings_[index];
+  }
+
+  void update_enabled_settings() {
+
+    CHORDS_SETTINGS *settings = enabled_settings_;
+
+    switch(get_menu_page()) {
+
+      case MENU_PARAMETERS: {
+
+        *settings++ = CHORDS_SETTING_MASK;
+        // hide root ?
+        if (get_scale(DUMMY2) != OC::Scales::SCALE_NONE)
+          *settings++ = CHORDS_SETTING_ROOT;
+        else
+           *settings++ = CHORDS_SETTING_MORE_DUMMY;
+
+        *settings++ = CHORDS_SETTING_PROGRESSION;
+        *settings++ = CHORDS_SETTING_CHORD_EDIT;
+        *settings++ = CHORDS_SETTING_PLAYMODES;
+        if (get_playmode() < _SH1)
+          *settings++ = CHORDS_SETTING_DIRECTION;
+        if (get_direction() == CHORDS_BROWNIAN)
+          *settings++ = CHORDS_SETTING_BROWNIAN_PROBABILITY;
+        *settings++ = CHORDS_SETTING_TRANSPOSE;
+        *settings++ = CHORDS_SETTING_OCTAVE;
+        *settings++ = CHORDS_SETTING_CV_SOURCE;
+        *settings++ = CHORDS_SETTING_CHORDS_ADVANCE_TRIGGER_SOURCE;
+        *settings++ = CHORDS_SETTING_TRIGGER_DELAY;
+      }
+      break;
+      case MENU_CV_MAPPING: {
+
+        *settings++ = CHORDS_SETTING_MASK_CV;
+        // destinations:
+        // hide root CV?
+        if (get_scale(DUMMY2) != OC::Scales::SCALE_NONE)
+          *settings++ = CHORDS_SETTING_ROOT_CV;
+        else
+           *settings++ = CHORDS_SETTING_MORE_DUMMY;
+
+        *settings++ = CHORDS_SETTING_PROGRESSION_CV;
+        *settings++ = CHORDS_SETTING_CHORD_EDIT;
+        *settings++ = CHORDS_SETTING_NUM_CHORDS_CV;
+        if (get_playmode() < _SH1)
+          *settings++ = CHORDS_SETTING_DIRECTION_CV;
+        if (get_direction() == CHORDS_BROWNIAN)
+          *settings++ = CHORDS_SETTING_BROWNIAN_CV;
+        *settings++ = CHORDS_SETTING_TRANSPOSE_CV;
+        *settings++ = CHORDS_SETTING_OCTAVE_CV;
+        *settings++ = CHORDS_SETTING_QUALITY_CV;
+        *settings++ = CHORDS_SETTING_INVERSION_CV;
+        *settings++ = CHORDS_SETTING_VOICING_CV;
+      }
+      break;
+      default:
+      break;
+    }
+    // end switch
+    num_enabled_settings_ = settings - enabled_settings_;
+  }
+
+  void RenderScreensaver(weegfx::coord_t x) const;
+
+private:
+  bool force_update_;
+  bool _octave_toggle;
+  int last_scale_;
+  uint16_t last_mask_;
+  int32_t last_sample_;
+  uint8_t display_num_chords_;
+  bool chord_advance_last_;
+  bool progression_advance_last_;
+  int8_t active_chord_;
+  int8_t progression_cnt_;
+  int8_t progression_EoP_;
+  bool chord_repeat_;
+  int8_t active_progression_;
+  int8_t menu_page_;
+  bool chords_direction_;
+  int8_t playmode_last_;
+  int8_t progression_last_;
+  int8_t num_chords_last_;
+
+  util::TriggerDelay<OC::kMaxTriggerDelayTicks> trigger_delay_;
+  braids::Quantizer quantizer_;
+  OC::Input_Map input_map_;
+  OC::DigitalInputDisplay clock_display_;
+  OC::Chords chords_;
+
+  int num_enabled_settings_;
+  CHORDS_SETTINGS enabled_settings_[CHORDS_SETTING_LAST];
+
+  bool update_scale(bool force, int32_t mask_rotate) {
+
+    force_update_ = false;
+    const int scale = get_scale(DUMMY2);
+    uint16_t mask = get_mask();
+
+    if (mask_rotate)
+      mask = OC::ScaleEditor<Chords>::RotateMask(mask, OC::Scales::GetScale(scale).num_notes, mask_rotate);
+
+    if (force || (last_scale_ != scale || last_mask_ != mask)) {
+      last_scale_ = scale;
+      last_mask_ = mask;
+      quantizer_.Configure(OC::Scales::GetScale(scale), mask);
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+const char* const chords_advance_trigger_sources[] = {
+  "TR1", "TR2"
+};
+
+const char* const chords_slots[] = {
+  "#1", "#2", "#3", "#4", "#5", "#6", "#7", "#8"
+};
+
+const char* const chord_playmodes[] = {
+  "-", "SEQ+1", "SEQ+2", "SEQ+3", "TR3+1", "TR3+2", "TR3+3", "S+H#1", "S+H#2", "S+H#3", "S+H#4", "CV#1", "CV#2", "CV#3", "CV#4"
+};
+
+SETTINGS_DECLARE(Chords, CHORDS_SETTING_LAST) {
+  { OC::Scales::SCALE_SEMI, OC::Scales::SCALE_SEMI, OC::Scales::NUM_SCALES - 1, "scale", OC::scale_names, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 11, "root", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 0, 0, OC::Chords::NUM_CHORD_PROGRESSIONS - 1, "progression", chords_slots, settings::STORAGE_TYPE_U8 },
+  { 65535, 1, 65535, "scale  -->", NULL, settings::STORAGE_TYPE_U16 }, // mask
+  { 0, 0, CHORDS_CV_SOURCE_LAST - 1, "CV source", OC::Strings::cv_input_names, settings::STORAGE_TYPE_U8 }, /// to do ..
+  { CHORDS_ADVANCE_TRIGGER_SOURCE_TR2, 0, CHORDS_ADVANCE_TRIGGER_SOURCE_LAST - 1, "chords trg src", chords_advance_trigger_sources, settings::STORAGE_TYPE_U8 },
+  { 0, 0, CHORDS_PLAYMODES_LAST - 1, "playmode", chord_playmodes, settings::STORAGE_TYPE_U8 },
+  { 0, 0, CHORDS_DIRECTIONS_LAST - 1, "direction", OC::Strings::seq_directions, settings::STORAGE_TYPE_U8 },
+  { 64, 0, 255, "-->brown prob", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, OC::kNumDelayTimes - 1, "TR1 delay", OC::Strings::trigger_delay_times, settings::STORAGE_TYPE_U8 },
+  { 0, -5, 7, "transpose", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -4, 4, "octave", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, 0, OC::Chords::CHORDS_USER_LAST - 1, "chord:", chords_slots, settings::STORAGE_TYPE_U8 },
+  { 0, 0, OC::Chords::CHORDS_USER_LAST - 1, "num.chords", NULL, settings::STORAGE_TYPE_U8 }, // progression 1
+  { 0, 0, OC::Chords::CHORDS_USER_LAST - 1, "num.chords", NULL, settings::STORAGE_TYPE_U8 }, // progression 2
+  { 0, 0, OC::Chords::CHORDS_USER_LAST - 1, "num.chords", NULL, settings::STORAGE_TYPE_U8 }, // progression 3
+  { 0, 0, OC::Chords::CHORDS_USER_LAST - 1, "num.chords", NULL, settings::STORAGE_TYPE_U8 }, // progression 4
+  { 0, 0, 0, "chords -->", NULL, settings::STORAGE_TYPE_U4 }, // = chord editor
+  // CV
+  { 0, 0, 4, "root CV      >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "mask CV      >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "transpose CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "octave CV    >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "quality CV   >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "voicing CV   >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "inversion CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "prg.slot# CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "direction CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "-->br.prb CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "num.chrds CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 0, "-", NULL, settings::STORAGE_TYPE_U4 }, // DUMMY
+  { 0, 0, 0, " ", NULL, settings::STORAGE_TYPE_U4 }  // MORE DUMMY
+};
+
+class ChordQuantizer {
+public:
+  void Init() {
+    cursor.Init(CHORDS_SETTING_SCALE, CHORDS_SETTING_LAST - 1);
+    scale_editor.Init(false);
+    chord_editor.Init();
+    left_encoder_value = OC::Scales::SCALE_SEMI;
+  }
+
+  inline bool editing() const {
+    return cursor.editing();
+  }
+
+  inline int cursor_pos() const {
+    return cursor.cursor_pos();
+  }
+
+  OC::menu::ScreenCursor<OC::menu::kScreenLines> cursor;
+  // menu::ScreenCursor<menu::kScreenLines> cursor;
+  OC::ScaleEditor<Chords> scale_editor;
+  OC::ChordEditor<Chords> chord_editor;
+  int left_encoder_value;
+};
+
+ChordQuantizer chords_state;
+Chords chords;
+
+void CHORDS_init() {
+
+  chords.InitDefaults();
+  chords.Init();
+  chords_state.Init();
+  chords.update_enabled_settings();
+  chords_state.cursor.AdjustEnd(chords.num_enabled_settings() - 1);
+}
+
+size_t CHORDS_storageSize() {
+  return Chords::storageSize();
+}
+
+size_t CHORDS_save(void *storage) {
+  return chords.Save(storage);
+}
+
+size_t CHORDS_restore(const void *storage) {
+
+  size_t storage_size = chords.Restore(storage);
+  chords.update_enabled_settings();
+  chords_state.left_encoder_value = chords.get_scale(DUMMY2);
+  chords.set_scale(chords_state.left_encoder_value);
+  chords_state.cursor.AdjustEnd(chords.num_enabled_settings() - 1);
+  return storage_size;
+}
+
+void CHORDS_handleAppEvent(OC::AppEvent event) {
+  switch (event) {
+    case OC::APP_EVENT_RESUME:
+      chords_state.cursor.set_editing(false);
+      chords_state.scale_editor.Close();
+      chords_state.chord_editor.Close();
+      break;
+    case OC::APP_EVENT_SUSPEND:
+    case OC::APP_EVENT_SCREENSAVER_ON:
+    case OC::APP_EVENT_SCREENSAVER_OFF:
+      break;
+  }
+}
+
+void CHORDS_isr() {
+
+  uint32_t triggers = OC::DigitalInputs::clocked();
+  chords.Update(triggers);
+}
+
+void CHORDS_loop() {
+}
+
+void CHORDS_menu() {
+
+  OC::menu::TitleBar<0, 4, 0>::Draw();
+
+  // print scale
+  int scale = chords_state.left_encoder_value;
+  graphics.movePrintPos(5, 0);
+  graphics.print(OC::scale_names[scale]);
+  if (chords.get_scale(DUMMY2) == scale)
+    graphics.drawBitmap8(1, OC::menu::QuadTitleBar::kTextY, 4, OC::bitmap_indicator_4x8);
+
+  // active progression #
+  graphics.setPrintPos(106, 2);
+  if (chords.poke_octave_toggle())
+    graphics.print("+");
+  else
+    graphics.print("#");
+  graphics.print(chords.get_active_progression() + 0x1);
+
+  uint8_t clock_state = (chords.clockState() + 3) >> 2;
+  if (clock_state && !chords_state.chord_editor.active())
+    graphics.drawBitmap8(121, 2, 4, OC::bitmap_gate_indicators_8 + (clock_state << 2));
+
+  OC::menu::SettingsList<OC::menu::kScreenLines, 0, OC::menu::kDefaultValueX> settings_list(chords_state.cursor);
+  OC::menu::SettingsListItem list_item;
+
+  while (settings_list.available()) {
+
+    const int setting = chords.enabled_setting_at(settings_list.Next(list_item));
+    const int value = chords.get_value(setting);
+    const settings::value_attr &attr = Chords::value_attr(setting);
+
+    switch(setting) {
+
+      case CHORDS_SETTING_MASK:
+        OC::menu::DrawMask<false, 16, 8, 1>(OC::menu::kDisplayWidth, list_item.y, chords.get_rotated_mask(), OC::Scales::GetScale(chords.get_scale(DUMMY2)).num_notes);
+        list_item.DrawNoValue<false>(value, attr);
+        break;
+      case CHORDS_SETTING_DUMMY:
+      case CHORDS_SETTING_CHORD_EDIT:
+        // to do: draw something that makes sense, presumably some pre-made icons would work best.
+        OC::menu::DrawMiniChord(OC::menu::kDisplayWidth, list_item.y, chords.get_display_num_chords(), chords.active_chord());
+        list_item.DrawNoValue<false>(value, attr);
+        break;
+      case CHORDS_SETTING_MORE_DUMMY:
+        list_item.DrawNoValue<false>(value, attr);
+        break;
+      case CHORDS_SETTING_CHORD_SLOT:
+        //special case:
+        list_item.DrawValueMax(value, attr, chords.get_num_chords(chords.get_progression()));
+        break;
+      default:
+        list_item.DrawDefault(value, attr);
+        break;
+      }
+
+   if (chords_state.scale_editor.active())
+     chords_state.scale_editor.Draw();
+   else if (chords_state.chord_editor.active())
+     chords_state.chord_editor.Draw();
+  }
+}
+
+void CHORDS_handleEncoderEvent(const UI::Event &event) {
+
+  if (chords_state.scale_editor.active()) {
+    chords_state.scale_editor.HandleEncoderEvent(event);
+    return;
+  }
+  else if (chords_state.chord_editor.active()) {
+    chords_state.chord_editor.HandleEncoderEvent(event);
+    return;
+  }
+
+  if (OC::CONTROL_ENCODER_L == event.control) {
+
+    int value = chords_state.left_encoder_value + event.value;
+    CONSTRAIN(value, OC::Scales::SCALE_SEMI, OC::Scales::NUM_SCALES - 1);
+    chords_state.left_encoder_value = value;
+
+  } else if (OC::CONTROL_ENCODER_R == event.control) {
+
+    if (chords_state.editing()) {
+
+      CHORDS_SETTINGS setting = chords.enabled_setting_at(chords_state.cursor_pos());
+
+      if (CHORDS_SETTING_MASK != setting) {
+
+        if (chords.change_value(setting, event.value))
+          chords.force_update();
+
+        switch (setting) {
+          case CHORDS_SETTING_CHORD_SLOT:
+          // special case, slot shouldn't be > num.chords
+            if (chords.get_chord_slot() > chords.get_num_chords(chords.get_progression()))
+              chords.set_chord_slot(chords.get_num_chords(chords.get_progression()));
+            break;
+          case CHORDS_SETTING_DIRECTION:
+          case CHORDS_SETTING_PLAYMODES:
+          // show options, or don't:
+            chords.update_enabled_settings();
+            chords_state.cursor.AdjustEnd(chords.num_enabled_settings() - 1);
+            break;
+          default:
+            break;
+        }
+      }
+    } else {
+      chords_state.cursor.Scroll(event.value);
+    }
+  }
+}
+
+void CHORDS_topButton() {
+
+  if (chords.get_menu_page() == MENU_PARAMETERS) {
+
+    if (chords.octave_toggle())
+      chords.change_value(CHORDS_SETTING_OCTAVE, 1);
+    else
+      chords.change_value(CHORDS_SETTING_OCTAVE, -1);
+  }
+  else  {
+    chords.set_menu_page(MENU_PARAMETERS);
+    chords.update_enabled_settings();
+    chords_state.cursor.set_editing(false);
+  }
+}
+
+void CHORDS_lowerButton() {
+  // go the CV mapping
+
+  if (!chords_state.chord_editor.active() && !chords_state.scale_editor.active()) {
+
+    uint8_t _menu_page = chords.get_menu_page();
+
+    switch (_menu_page) {
+
+      case MENU_PARAMETERS:
+        _menu_page = MENU_CV_MAPPING;
+      break;
+      default:
+        _menu_page = MENU_PARAMETERS;
+      break;
+    }
+
+    chords.set_menu_page(_menu_page);
+    chords.update_enabled_settings();
+    chords_state.cursor.set_editing(false);
+  }
+}
+
+void CHORDS_rightButton() {
+
+  switch (chords.enabled_setting_at(chords_state.cursor_pos())) {
+
+    case CHORDS_SETTING_MASK: {
+      int scale = chords.get_scale(DUMMY2);
+      if (OC::Scales::SCALE_NONE != scale)
+        chords_state.scale_editor.Edit(&chords, scale);
+      }
+    break;
+    case CHORDS_SETTING_CHORD_EDIT:
+      chords_state.chord_editor.Edit(&chords, chords.get_chord_slot(), chords.get_num_chords(chords.get_progression()), chords.get_progression());
+    break;
+    case CHORDS_SETTING_DUMMY:
+    case CHORDS_SETTING_MORE_DUMMY:
+      chords.set_menu_page(MENU_PARAMETERS);
+      chords.update_enabled_settings();
+    break;
+    default:
+      chords_state.cursor.toggle_editing();
+    break;
+  }
+}
+
+void CHORDS_leftButton() {
+
+  if (chords_state.left_encoder_value != chords.get_scale(DUMMY2) || chords_state.left_encoder_value == OC::Scales::SCALE_SEMI) {
+    chords.set_scale(chords_state.left_encoder_value);
+    // hide/show root
+    chords.update_enabled_settings();
+  }
+}
+
+void CHORDS_leftButtonLong() {
+  // todo
+}
+
+void CHORDS_downButtonLong() {
+  chords.clear_CV_mapping();
+  chords_state.cursor.set_editing(false);
+}
+
+void CHORDS_upButtonLong() {
+  // screensaver short cut
+}
+
+void CHORDS_handleButtonEvent(const UI::Event &event) {
+
+  if (UI::EVENT_BUTTON_LONG_PRESS == event.type) {
+     switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+         CHORDS_upButtonLong();
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        CHORDS_downButtonLong();
+        break;
+       case OC::CONTROL_BUTTON_L:
+        if (!(chords_state.chord_editor.active()))
+          CHORDS_leftButtonLong();
+        break;
+      default:
+        break;
+     }
+  }
+
+  if (chords_state.scale_editor.active()) {
+    chords_state.scale_editor.HandleButtonEvent(event);
+    return;
+  }
+  else if (chords_state.chord_editor.active()) {
+    chords_state.chord_editor.HandleButtonEvent(event);
+    return;
+  }
+
+  if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        CHORDS_topButton();
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        CHORDS_lowerButton();
+        break;
+      case OC::CONTROL_BUTTON_L:
+        CHORDS_leftButton();
+        break;
+      case OC::CONTROL_BUTTON_R:
+        CHORDS_rightButton();
+        break;
+    }
+  }
+}
+
+static const weegfx::coord_t chords_kBottom = 60;
+
+inline int32_t chords_render_pitch(int32_t pitch, weegfx::coord_t x, weegfx::coord_t width) {
+
+  CONSTRAIN(pitch, 0, 120 << 7);
+  int32_t octave = pitch / (12 << 7);
+  pitch -= (octave * 12 << 7);
+  graphics.drawHLine(x, chords_kBottom - ((pitch * 4) >> 7), width << 1);
+  return octave;
+}
+
+void Chords::RenderScreensaver(weegfx::coord_t start_x) const {
+
+  // int _active_chord = active_chord();
+  // int _num_progression = get_active_progression();
+  // int _num_chords = get_display_num_chords();
+  // int x = start_x + 4;
+  // int y = 42;
+
+  // // todo: CV
+  // for (int j = 0; j <= _num_chords; j++) {
+
+  //   // if (j == _active_chord)
+  //   //   OC::menu::DrawChord(x + (j << 4) + 1, y, 6, j, _num_progression);
+  //   // else
+  //   //   OC::menu::DrawChord(x + (j << 4) + 2, y, 4, j, _num_progression);
+  // }
+}
+
+
+void CHORDS_screensaver() {
+#ifdef CHORDS_DEBUG_SCREENSAVER
+  debug::CycleMeasurement render_cycles;
+#endif
+
+  chords.RenderScreensaver(0);
+
+#ifdef CHORDS_DEBUG_SCREENSAVER
+  graphics.drawHLine(0, menu::kMenuLineH, menu::kDisplayWidth);
+  uint32_t us = debug::cycles_to_us(render_cycles.read());
+  graphics.setPrintPos(0, 32);
+  graphics.printf("%u",  us);
+#endif
+}

--- a/software/o_c_REV/APP_DQ.ino
+++ b/software/o_c_REV/APP_DQ.ino
@@ -1,0 +1,1570 @@
+// Copyright (c) 2015, 2016 Patrick Dowling, Tim Churches, Max Stadler
+//
+// Initial app implementation: Patrick Dowling (pld@gurkenkiste.com)
+// Modifications by: Tim Churches (tim.churches@gmail.com)
+// Yet more Modifications by: mxmxmx
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Quad quantizer app, based around the the quantizer/scales implementation from
+// from Braids by Olivier Gillet (see braids_quantizer.h/cc et al.). It has since
+// grown a little bit...
+
+#include "OC_apps.h"
+#include "util/util_settings.h"
+#include "util/util_trigger_delay.h"
+#include "braids_quantizer.h"
+#include "braids_quantizer_scales.h"
+#include "OC_menus.h"
+#include "OC_visualfx.h"
+#include "OC_scales.h"
+#include "OC_scale_edit.h"
+#include "OC_strings.h"
+#include "OC_digital_inputs.h"
+#include "OC_ADC.h"
+#include "extern/dspinst.h"
+
+#ifdef BUCHLA_4U
+ #define DQ_OFFSET_X 22
+#else
+ #define DQ_OFFSET_X 47
+#endif
+
+const uint8_t NUMCHANNELS = 2;
+const uint8_t NUM_SCALE_SLOTS = 4;
+// const uint8_t PULSEW_MAX = 255;
+// const uint32_t TICKS_TO_MS = 43691;
+
+enum DQ_ChannelSetting {
+  DQ_CHANNEL_SETTING_SCALE1,
+  DQ_CHANNEL_SETTING_SCALE2,
+  DQ_CHANNEL_SETTING_SCALE3,
+  DQ_CHANNEL_SETTING_SCALE4,
+  DQ_CHANNEL_SETTING_ROOT1,
+  DQ_CHANNEL_SETTING_ROOT2,
+  DQ_CHANNEL_SETTING_ROOT3,
+  DQ_CHANNEL_SETTING_ROOT4,
+  DQ_CHANNEL_SETTING_SCALE_SEQ,
+  DQ_CHANNEL_SETTING_MASK1,
+  DQ_CHANNEL_SETTING_MASK2,
+  DQ_CHANNEL_SETTING_MASK3,
+  DQ_CHANNEL_SETTING_MASK4,
+  DQ_CHANNEL_SETTING_SEQ_MODE,
+  DQ_CHANNEL_SETTING_SOURCE,
+  DQ_CHANNEL_SETTING_TRIGGER,
+  DQ_CHANNEL_SETTING_DELAY,
+  DQ_CHANNEL_SETTING_TRANSPOSE1,
+  DQ_CHANNEL_SETTING_TRANSPOSE2,
+  DQ_CHANNEL_SETTING_TRANSPOSE3,
+  DQ_CHANNEL_SETTING_TRANSPOSE4,
+  DQ_CHANNEL_SETTING_OCTAVE,
+  DQ_CHANNEL_SETTING_AUX_OUTPUT,
+  DQ_CHANNEL_SETTING_PULSEWIDTH,
+  DQ_CHANNEL_SETTING_AUX_OCTAVE,
+  DQ_CHANNEL_SETTING_AUX_CV_DEST,
+  DQ_CHANNEL_SETTING_TURING_LENGTH,
+  DQ_CHANNEL_SETTING_TURING_PROB,
+  DQ_CHANNEL_SETTING_TURING_CV_SOURCE,
+  DQ_CHANNEL_SETTING_TURING_RANGE,
+  DQ_CHANNEL_SETTING_TURING_TRIG_OUT,
+  DQ_CHANNEL_SETTING_LAST
+};
+
+enum DQ_ChannelTriggerSource {
+  DQ_CHANNEL_TRIGGER_TR1,
+  DQ_CHANNEL_TRIGGER_TR2,
+  DQ_CHANNEL_TRIGGER_TR3,
+  DQ_CHANNEL_TRIGGER_TR4,
+  DQ_CHANNEL_TRIGGER_CONTINUOUS_UP,
+  DQ_CHANNEL_TRIGGER_CONTINUOUS_DOWN,
+  DQ_CHANNEL_TRIGGER_LAST
+};
+
+enum DQ_ChannelSource {
+  DQ_CHANNEL_SOURCE_CV1,
+  DQ_CHANNEL_SOURCE_CV2,
+  DQ_CHANNEL_SOURCE_CV3,
+  DQ_CHANNEL_SOURCE_CV4,
+  DQ_CHANNEL_SOURCE_TURING,
+  DQ_CHANNEL_SOURCE_LOGISTIC_MAP,
+  DQ_CHANNEL_SOURCE_BYTEBEAT,
+  DQ_CHANNEL_SOURCE_INT_SEQ,
+  DQ_CHANNEL_SOURCE_LAST
+};
+
+enum DQ_AUX_MODE {
+  DQ_GATE,
+  DQ_COPY,
+  DQ_ASR,
+  DQ_AUX_MODE_LAST
+};
+
+enum TRIG_AUX_MODE {
+  DQ_ECHO,
+  DQ_LSB,
+  DQ_CHANGE,
+  DQ_TRIG_AUX_LAST
+};
+
+enum DQ_CV_DEST {
+  DQ_DEST_NONE,
+  DQ_DEST_SCALE_SLOT,
+  DQ_DEST_ROOT,
+  DQ_DEST_OCTAVE,
+  DQ_DEST_TRANSPOSE,
+  DQ_DEST_MASK,
+  DQ_DEST_LAST
+};
+
+enum DQ_SLOTS {
+  SLOT1,
+  SLOT2,
+  SLOT3,
+  SLOT4,
+  LAST_SLOT
+};
+
+void DQ_topButton();
+void DQ_lowerButton();
+void DQ_leftButton();
+void DQ_rightButton();
+void DQ_leftButtonLong();
+void DQ_rightButton();
+void DQ_leftButton();
+void DQ_lowerButton();
+void DQ_topButton();
+void DQ_downButtonLong();
+
+class DQ_QuantizerChannel : public settings::SettingsBase<DQ_QuantizerChannel, DQ_CHANNEL_SETTING_LAST> {
+public:
+  enum DQ_STATES {
+    OFF,
+    ON = 0xFFFF
+  };
+  int get_scale(uint8_t selected_scale_slot_) const {
+
+    switch(selected_scale_slot_) {
+
+       case SLOT2:
+        return values_[DQ_CHANNEL_SETTING_SCALE2];
+       break;
+       case SLOT3:
+        return values_[DQ_CHANNEL_SETTING_SCALE3];
+       break;
+       case SLOT4:
+        return values_[DQ_CHANNEL_SETTING_SCALE4];
+       break;
+       case SLOT1:
+       default:
+        return values_[DQ_CHANNEL_SETTING_SCALE1];
+       break;
+    }
+  }
+
+  int get_scale_select() const {
+    return values_[DQ_CHANNEL_SETTING_SCALE_SEQ];
+  }
+
+  int get_scale_seq_mode() const {
+    return values_[DQ_CHANNEL_SETTING_SEQ_MODE];
+  }
+
+  int get_display_scale() const {
+    return display_scale_slot_;
+  }
+
+  int get_display_root() const {
+    return display_root_;
+  }
+
+  void set_scale_at_slot(int scale, uint16_t mask, int root, int transpose, uint8_t scale_slot) {
+
+    if (scale != get_scale(scale_slot) || mask != get_mask(scale_slot) || root != root_last_ || transpose != transpose_last_) {
+
+      const OC::Scale &scale_def = OC::Scales::GetScale(scale);
+      root_last_ = root;
+      transpose_last_ = transpose;
+
+      if (0 == (mask & ~(0xffff << scale_def.num_notes)))
+        mask |= 0x1;
+      switch (scale_slot) {
+        case SLOT2:
+        apply_value(DQ_CHANNEL_SETTING_MASK2, mask);
+        apply_value(DQ_CHANNEL_SETTING_SCALE2, scale);
+        apply_value(DQ_CHANNEL_SETTING_ROOT2, root);
+        apply_value(DQ_CHANNEL_SETTING_TRANSPOSE2, transpose);
+        break;
+        case SLOT3:
+        apply_value(DQ_CHANNEL_SETTING_MASK3, mask);
+        apply_value(DQ_CHANNEL_SETTING_SCALE3, scale);
+        apply_value(DQ_CHANNEL_SETTING_ROOT3, root);
+        apply_value(DQ_CHANNEL_SETTING_TRANSPOSE3, transpose);
+        break;
+        case SLOT4:
+        apply_value(DQ_CHANNEL_SETTING_MASK4, mask);
+        apply_value(DQ_CHANNEL_SETTING_SCALE4, scale);
+        apply_value(DQ_CHANNEL_SETTING_ROOT4, root);
+        apply_value(DQ_CHANNEL_SETTING_TRANSPOSE4, transpose);
+        break;
+        case SLOT1:
+        default:
+        apply_value(DQ_CHANNEL_SETTING_MASK1, mask);
+        apply_value(DQ_CHANNEL_SETTING_SCALE1, scale);
+        apply_value(DQ_CHANNEL_SETTING_ROOT1, root);
+        apply_value(DQ_CHANNEL_SETTING_TRANSPOSE1, transpose);
+        break;
+      }
+    }
+  }
+
+  int get_root(uint8_t selected_scale_slot_) const {
+
+    switch(selected_scale_slot_) {
+
+       case SLOT2:
+        return values_[DQ_CHANNEL_SETTING_ROOT2];
+       break;
+       case SLOT3:
+        return values_[DQ_CHANNEL_SETTING_ROOT3];
+       break;
+       case SLOT4:
+        return values_[DQ_CHANNEL_SETTING_ROOT4];
+       break;
+       case SLOT1:
+       default:
+        return values_[DQ_CHANNEL_SETTING_ROOT1];
+       break;
+    }
+  }
+
+  uint16_t get_mask(uint8_t selected_scale_slot_) const {
+
+    switch(selected_scale_slot_) {
+
+      case SLOT2:
+        return values_[DQ_CHANNEL_SETTING_MASK2];
+      break;
+      case SLOT3:
+        return values_[DQ_CHANNEL_SETTING_MASK3];
+      break;
+      case SLOT4:
+        return values_[DQ_CHANNEL_SETTING_MASK4];
+      break;
+      case SLOT1:
+      default:
+        return values_[DQ_CHANNEL_SETTING_MASK1];
+      break;
+    }
+  }
+
+  uint16_t get_rotated_mask(uint8_t selected_scale_slot_) const {
+      return last_mask_[selected_scale_slot_];
+  }
+
+  DQ_ChannelSource get_source() const {
+    return static_cast<DQ_ChannelSource>(values_[DQ_CHANNEL_SETTING_SOURCE]);
+  }
+
+  DQ_ChannelTriggerSource get_trigger_source() const {
+    return static_cast<DQ_ChannelTriggerSource>(values_[DQ_CHANNEL_SETTING_TRIGGER]);
+  }
+
+  OC::DigitalInput get_digital_input() const {
+    return static_cast<OC::DigitalInput>(values_[DQ_CHANNEL_SETTING_TRIGGER]);
+  }
+
+  uint8_t get_aux_cv_dest() const {
+    return values_[DQ_CHANNEL_SETTING_AUX_CV_DEST];
+  }
+
+  uint16_t get_trigger_delay() const {
+    return values_[DQ_CHANNEL_SETTING_DELAY];
+  }
+
+  int get_transpose(uint8_t selected_scale_slot_) const {
+
+    switch(selected_scale_slot_) {
+
+      case SLOT2:
+        return values_[DQ_CHANNEL_SETTING_TRANSPOSE2];
+      break;
+      case SLOT3:
+        return values_[DQ_CHANNEL_SETTING_TRANSPOSE3];
+      break;
+      case SLOT4:
+        return values_[DQ_CHANNEL_SETTING_TRANSPOSE4];
+      break;
+      case SLOT1:
+      default:
+        return values_[DQ_CHANNEL_SETTING_TRANSPOSE1];
+      break;
+    }
+  }
+
+  int get_octave() const {
+    return values_[DQ_CHANNEL_SETTING_OCTAVE];
+  }
+
+  int get_aux_mode() const {
+    return values_[DQ_CHANNEL_SETTING_AUX_OUTPUT];
+  }
+
+  int get_aux_octave() const {
+    return values_[DQ_CHANNEL_SETTING_AUX_OCTAVE];
+  }
+
+  int get_pulsewidth() const {
+    return values_[DQ_CHANNEL_SETTING_PULSEWIDTH];
+  }
+
+  uint8_t get_turing_length() const {
+    return values_[DQ_CHANNEL_SETTING_TURING_LENGTH];
+  }
+
+  uint8_t get_turing_display_length() const {
+    return turing_display_length_;
+  }
+
+  uint8_t get_turing_range() const {
+    return values_[DQ_CHANNEL_SETTING_TURING_RANGE];
+  }
+
+  uint8_t get_turing_probability() const {
+    return values_[DQ_CHANNEL_SETTING_TURING_PROB];
+  }
+
+  uint8_t get_turing_CV() const {
+    return values_[DQ_CHANNEL_SETTING_TURING_CV_SOURCE];
+  }
+
+  uint8_t get_turing_trig_out() const {
+    return values_[DQ_CHANNEL_SETTING_TURING_TRIG_OUT];
+  }
+
+  uint32_t get_shift_register() const {
+    return turing_machine_.get_shift_register();
+  }
+
+  void clear_dest() {
+    // ...
+    schedule_mask_rotate_ = 0x0;
+    continuous_offset_ = 0x0;
+    prev_transpose_cv_ = 0x0;
+    prev_octave_cv_ = 0x0;
+    prev_root_cv_ = 0x0;
+    prev_scale_cv_ = 0x0;
+  }
+
+  void reset_scale() {
+    scale_reset_ = true;
+  }
+
+  void Init(DQ_ChannelSource source, DQ_ChannelTriggerSource trigger_source) {
+
+    InitDefaults();
+    apply_value(DQ_CHANNEL_SETTING_SOURCE, source);
+    apply_value(DQ_CHANNEL_SETTING_TRIGGER, trigger_source);
+
+    force_update_ = true;
+
+    for (int i = 0; i < NUM_SCALE_SLOTS; i++) {
+      last_scale_[i] = -1;
+      last_mask_[i] = 0xFFFF;
+    }
+
+    aux_sample_ = 0;
+    last_sample_ = 0;
+    last_aux_sample_ = 0;
+    continuous_offset_ = 0;
+    scale_sequence_cnt_ = 0;
+    scale_reset_ = 0;
+    active_scale_slot_ = 0;
+    display_scale_slot_ = 0;
+    display_root_ = 0;
+    root_last_ = 0;
+    transpose_last_ = 0;
+    prev_scale_slot_ = 0;
+    scale_advance_ = 0;
+    scale_advance_state_ = 0;
+    schedule_scale_update_ = 0;
+    schedule_mask_rotate_ = 0;
+    prev_octave_cv_ = 0;
+    prev_transpose_cv_ = 0;
+    prev_root_cv_ = 0;
+    prev_scale_cv_ = 0;
+    prev_destination_ = 0;
+    prev_pulsewidth_ = 100;
+    ticks_ = 0;
+    channel_frequency_in_ticks_ = 1000;
+    pulse_width_in_ticks_ = 1000;
+
+    trigger_delay_.Init();
+    quantizer_.Init();
+    update_scale(true, 0, false);
+    trigger_display_.Init();
+    update_enabled_settings();
+
+    turing_machine_.Init();
+    turing_display_length_ = get_turing_length();
+
+    scrolling_history_.Init(OC::DAC::kOctaveZero * 12 << 7);
+  }
+
+  void force_update() {
+    force_update_ = true;
+  }
+
+  void schedule_scale_update() {
+    schedule_scale_update_ = true;
+  }
+
+  inline void Update(uint32_t triggers, DAC_CHANNEL dac_channel, DAC_CHANNEL aux_channel) {
+
+    ticks_++;
+
+    DQ_ChannelTriggerSource trigger_source = get_trigger_source();
+    bool continuous = DQ_CHANNEL_TRIGGER_CONTINUOUS_UP == trigger_source || DQ_CHANNEL_TRIGGER_CONTINUOUS_DOWN == trigger_source;
+    bool triggered = !continuous &&
+      (triggers & DIGITAL_INPUT_MASK(trigger_source - DQ_CHANNEL_TRIGGER_TR1));
+
+    trigger_delay_.Update();
+    if (triggered)
+      trigger_delay_.Push(OC::trigger_delay_ticks[get_trigger_delay()]);
+    triggered = trigger_delay_.triggered();
+
+    if (triggered) {
+      channel_frequency_in_ticks_ = ticks_;
+      ticks_ = 0x0;
+      update_asr_ = true;
+      aux_sample_ = ON;
+    }
+
+    if (scale_reset_) {
+      // manual change?
+      scale_reset_ = false;
+      scale_sequence_cnt_ = 0x0;
+      scale_advance_state_ = 0x1;
+      active_scale_slot_ = get_scale_select();
+      prev_scale_slot_ = display_scale_slot_ = active_scale_slot_;
+    }
+
+    if (get_scale_seq_mode()) {
+        // to do, don't hardcode ..
+      uint8_t _advance_trig = (dac_channel == DAC_CHANNEL_A) ? digitalReadFast(TR2) : digitalReadFast(TR4);
+      if (_advance_trig < scale_advance_state_)
+        scale_advance_ = true;
+      scale_advance_state_ = _advance_trig;
+    }
+    else if (prev_scale_slot_ != get_scale_select()) {
+      active_scale_slot_ = get_scale_select();
+      prev_scale_slot_ = display_scale_slot_ = active_scale_slot_;
+    }
+
+    if (scale_advance_) {
+      scale_sequence_cnt_++;
+      active_scale_slot_ = get_scale_select() + (scale_sequence_cnt_ % (get_scale_seq_mode() + 1));
+
+      if (active_scale_slot_ >= NUM_SCALE_SLOTS)
+        active_scale_slot_ -= NUM_SCALE_SLOTS;
+      scale_advance_ = false;
+      schedule_scale_update_ = true;
+    }
+
+    bool update = continuous || triggered;
+
+    int32_t sample = last_sample_;
+    int32_t temp_sample = 0;
+    int32_t history_sample = 0;
+    uint8_t aux_mode = get_aux_mode();
+
+    if (update) {
+
+      int32_t transpose, pitch, quantized = 0x0;
+      int source, cv_source, channel_id, octave, root, _aux_cv_destination;
+
+      source = cv_source = get_source();
+      _aux_cv_destination = get_aux_cv_dest();
+      channel_id = (dac_channel == DAC_CHANNEL_A) ? 1 : 3; // hardcoded to use CV2, CV4, for now
+
+      if (_aux_cv_destination != prev_destination_)
+        clear_dest();
+      prev_destination_ = _aux_cv_destination;
+      // active scale slot:
+      display_scale_slot_ = prev_scale_slot_ = active_scale_slot_ + prev_scale_cv_;
+      // get root value
+      root = get_root(display_scale_slot_) + prev_root_cv_;
+      // get transpose value
+      transpose = get_transpose(display_scale_slot_) + prev_transpose_cv_;
+      // get octave value
+      octave = get_octave() + prev_octave_cv_;
+
+      // S/H: ADC values
+      if (!continuous) {
+
+        switch(_aux_cv_destination) {
+
+          case DQ_DEST_NONE:
+          break;
+          case DQ_DEST_SCALE_SLOT:
+            display_scale_slot_ += (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 255) >> 9;
+            // if scale changes, we have to update the root and transpose values, too; mask gets updated in update_scale
+            root = get_root(display_scale_slot_);
+            transpose = get_transpose(display_scale_slot_);
+            schedule_scale_update_ = true;
+          break;
+          case DQ_DEST_ROOT:
+              root += (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 127) >> 8;
+          break;
+          case DQ_DEST_MASK:
+              schedule_mask_rotate_ = (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 127) >> 8;
+          break;
+          case DQ_DEST_OCTAVE:
+            octave += (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 255) >> 9;
+          break;
+          case DQ_DEST_TRANSPOSE:
+            transpose += (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 64) >> 7;
+          break;
+          default:
+          break;
+        } // end switch
+
+        if (schedule_scale_update_) {
+          force_update_ = true;
+          schedule_scale_update_ = false;
+        }
+      } // -> triggered update
+
+      // constrain values:
+      CONSTRAIN(display_scale_slot_, 0, NUM_SCALE_SLOTS-1);
+      CONSTRAIN(octave, -4, 4);
+      CONSTRAIN(root, 0, 11);
+      CONSTRAIN(transpose, -12, 12);
+
+      // update scale?
+      update_scale(force_update_, display_scale_slot_, schedule_mask_rotate_);
+
+      // internal CV source?
+      if (source > DQ_CHANNEL_SOURCE_CV4)
+        cv_source = channel_id - 1;
+
+      // now, acquire + process sample:
+      pitch = quantizer_.enabled()
+                ? OC::ADC::raw_pitch_value(static_cast<ADC_CHANNEL>(cv_source))
+                : OC::ADC::pitch_value(static_cast<ADC_CHANNEL>(cv_source));
+
+      switch (source) {
+
+        case DQ_CHANNEL_SOURCE_CV1:
+        case DQ_CHANNEL_SOURCE_CV2:
+        case DQ_CHANNEL_SOURCE_CV3:
+        case DQ_CHANNEL_SOURCE_CV4:
+        quantized = quantizer_.Process(pitch, root << 7, transpose);
+        break;
+        case DQ_CHANNEL_SOURCE_TURING:
+        {
+          if (continuous)
+              break;
+
+          int16_t _length = get_turing_length();
+          int16_t _probability = get_turing_probability();
+          int16_t _range = get_turing_range();
+
+          // _pitch can do other things now --
+          switch (get_turing_CV()) {
+
+              case 1:  // range
+               _range += ((pitch + 63) >> 6);
+               CONSTRAIN(_range, 1, 120);
+              case 2:  // LEN, 1-32
+               _length += ((pitch + 255) >> 8);
+               CONSTRAIN(_length, 1, 32);
+              break;
+               case 3:  // P
+               _probability += ((pitch + 15) >> 4);
+               CONSTRAIN(_probability, 0, 255);
+              break;
+              default:
+              break;
+          }
+
+          turing_machine_.set_length(_length);
+          turing_machine_.set_probability(_probability);
+          turing_display_length_ = _length;
+
+          uint32_t _shift_register = turing_machine_.Clock();
+          // Since our range is limited anyway, just grab the last byte for lengths > 8, otherwise scale to use bits.
+          uint32_t shift = turing_machine_.length();
+          uint32_t _scaled = (_shift_register & 0xFF) * _range;
+          _scaled = _scaled >> (shift > 7 ? 8 : shift);
+          quantized = quantizer_.Lookup(64 + _range / 2 - _scaled + transpose) + (root<< 7);
+        }
+        break;
+        default:
+        break;
+      }
+
+      // the output, thus far:
+      sample = temp_sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, quantized, octave + continuous_offset_, OC::DAC::get_voltage_scaling(dac_channel));
+
+      // special treatment, continuous update -- only update the modulation values if/when the quantized input changes:
+      bool _continuous_update = continuous && last_sample_ != sample;
+
+      if (_continuous_update) {
+
+          bool _re_quantize = false;
+          int _aux_cv = 0;
+
+          switch(_aux_cv_destination) {
+
+            case DQ_DEST_NONE:
+            break;
+            case DQ_DEST_SCALE_SLOT:
+            _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 255) >> 9;
+            if (_aux_cv !=  prev_scale_cv_) {
+                display_scale_slot_ += _aux_cv;
+                CONSTRAIN(display_scale_slot_, 0, NUM_SCALE_SLOTS - 0x1);
+                prev_scale_cv_ = _aux_cv;
+                // update the root and transpose values
+                root = get_root(display_scale_slot_);
+                transpose = get_transpose(display_scale_slot_);
+                // and update quantizer below:
+                schedule_scale_update_ = true;
+                _re_quantize = true;
+            }
+            break;
+            case DQ_DEST_TRANSPOSE:
+              _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 63) >> 7;
+              if (_aux_cv != prev_transpose_cv_) {
+                  transpose = get_transpose(display_scale_slot_) + _aux_cv;
+                  CONSTRAIN(transpose, -12, 12);
+                  prev_transpose_cv_ = _aux_cv;
+                  _re_quantize = true;
+              }
+            break;
+            case DQ_DEST_ROOT:
+              _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 127) >> 8;
+              if (_aux_cv != prev_root_cv_) {
+                  display_root_ = root = get_root(display_scale_slot_) + _aux_cv;
+                  CONSTRAIN(root, 0, 11);
+                  prev_root_cv_ = _aux_cv;
+                  _re_quantize = true;
+              }
+            break;
+            case DQ_DEST_OCTAVE:
+              _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 255) >> 9;
+              if (_aux_cv != prev_octave_cv_) {
+                  octave = get_octave() + _aux_cv;
+                  CONSTRAIN(octave, -4, 4);
+                  prev_octave_cv_ = _aux_cv;
+                  _re_quantize = true;
+              }
+            break;
+            case DQ_DEST_MASK:
+              schedule_mask_rotate_ = (OC::ADC::value(static_cast<ADC_CHANNEL>(channel_id)) + 127) >> 8;
+              schedule_scale_update_ = true;
+            break;
+            default:
+            break;
+          }
+          // end switch
+
+          // update scale?
+          if (schedule_scale_update_ && _continuous_update) {
+            update_scale(true, display_scale_slot_, schedule_mask_rotate_);
+            schedule_scale_update_ = false;
+          }
+
+          // offset when TR source = continuous ?
+          int8_t _trigger_offset = 0;
+          bool _trigger_update = false;
+          if (OC::DigitalInputs::read_immediate(static_cast<OC::DigitalInput>(channel_id - 1))) {
+             _trigger_offset = (trigger_source == DQ_CHANNEL_TRIGGER_CONTINUOUS_UP) ? 1 : -1;
+          }
+          if (_trigger_offset != continuous_offset_)
+            _trigger_update = true;
+          continuous_offset_ = _trigger_offset;
+
+          // run quantizer again -- presumably could be made more efficient...
+          if (_re_quantize)
+            quantized = quantizer_.Process(pitch, root << 7, transpose);
+          if (_re_quantize || _trigger_update)
+            sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, quantized, octave + continuous_offset_, OC::DAC::get_voltage_scaling(dac_channel));
+          // update ASR?
+          update_asr_ = (aux_mode == DQ_ASR && last_sample_ != sample);
+
+      }
+      // end special treatment
+
+      display_root_ = root;
+      history_sample = quantized + ((OC::DAC::kOctaveZero + octave) * 12 << 7);
+
+      // deal with aux output:
+      switch (aux_mode) {
+
+        case DQ_COPY:
+        // offset the quantized value:
+          aux_sample_ = OC::DAC::pitch_to_scaled_voltage_dac(aux_channel, quantized, octave + continuous_offset_ + get_aux_octave(), OC::DAC::get_voltage_scaling(aux_channel));
+        break;
+        case DQ_ASR:
+        {
+          if (update_asr_) {
+            update_asr_ = false;
+            aux_sample_ = OC::DAC::pitch_to_scaled_voltage_dac(aux_channel, last_aux_sample_, octave + continuous_offset_ + get_aux_octave(), OC::DAC::get_voltage_scaling(aux_channel));
+            last_aux_sample_ = quantized;
+          }
+        }
+        break;
+        case DQ_GATE: {
+
+           if (source == DQ_CHANNEL_SOURCE_TURING) {
+
+            switch(get_turing_trig_out()) {
+
+              case DQ_ECHO:
+              break;
+              case DQ_LSB:
+              if (!turing_machine_.get_LSB())
+                aux_sample_ = OFF;
+              break;
+              case DQ_CHANGE:
+              if (last_sample_ == sample)
+                aux_sample_ = OFF;
+              break;
+              default:
+              break;
+            }
+          }
+        }
+        break;
+        default:
+        break;
+      }
+    }
+
+    // in continuous mode, don't track transposed sample:
+    bool changed = continuous ? (last_sample_ != temp_sample) : (last_sample_ != sample);
+
+    if (changed) {
+
+      MENU_REDRAW = 1;
+      last_sample_ = continuous ? temp_sample : sample;
+
+      // in continuous mode, make aux output go high:
+      if (continuous && aux_mode == DQ_GATE) {
+        aux_sample_ = ON;
+        ticks_ = 0x0;
+      }
+    }
+
+    // aux outputs:
+    int32_t aux_sample = aux_sample_;
+
+    switch (aux_mode) {
+
+      case DQ_COPY:
+      case DQ_ASR:
+      break;
+      case DQ_GATE:
+      {
+      if (aux_sample) {
+
+            // pulsewidth setting --
+            int16_t _pulsewidth = get_pulsewidth();
+
+            if (_pulsewidth || continuous) { // don't echo
+
+                bool _gates = false;
+
+                if (_pulsewidth == 255)
+                  _gates = true;
+                // we-can't-echo-hack
+                if (continuous && !_pulsewidth)
+                  _pulsewidth = 0x1;
+
+                // recalculate (in ticks), if new pulsewidth setting:
+                if (prev_pulsewidth_ != _pulsewidth || ! ticks_) {
+
+                    if (!_gates) {
+                      int32_t _fraction = signed_multiply_32x16b(43691, static_cast<int32_t>(_pulsewidth)); // = * 0.6667f
+                      _fraction = signed_saturate_rshift(_fraction, 16, 0);
+                      pulse_width_in_ticks_  = (_pulsewidth << 4) + _fraction;
+                    }
+                    else { // put out gates/half duty cycle:
+
+                      pulse_width_in_ticks_ = channel_frequency_in_ticks_ >> 1;
+
+                      if (_pulsewidth != 255) { // CV?
+                        pulse_width_in_ticks_ = signed_multiply_32x16b(static_cast<int32_t>(_pulsewidth) << 8, pulse_width_in_ticks_); //
+                        pulse_width_in_ticks_ = signed_saturate_rshift(pulse_width_in_ticks_, 16, 0);
+                      }
+                    }
+                }
+                prev_pulsewidth_ = _pulsewidth;
+
+                // limit pulsewidth, if approaching half duty cycle:
+                if (!_gates && pulse_width_in_ticks_ >= channel_frequency_in_ticks_>>1)
+                  pulse_width_in_ticks_ = (channel_frequency_in_ticks_ >> 1) | 1u;
+
+                // turn off output?
+                if (ticks_ >= pulse_width_in_ticks_)
+                  aux_sample_ = OFF;
+                else // keep on
+                  aux_sample_ = ON;
+             }
+             else {
+                // we simply echo the pulsewidth:
+                 aux_sample_ = OC::DigitalInputs::read_immediate(get_digital_input()) ? ON : OFF;
+             }
+         }
+      }
+      // scale gate
+      #ifdef BUCHLA_4U
+        aux_sample = (aux_sample_ == ON) ? OC::DAC::get_octave_offset(aux_channel, OCTAVES - OC::DAC::kOctaveZero - 0x2) : OC::DAC::get_zero_offset(aux_channel);
+      #else
+        aux_sample = (aux_sample_ == ON) ? OC::DAC::get_octave_offset(aux_channel, OCTAVES - OC::DAC::kOctaveZero - 0x1) : OC::DAC::get_zero_offset(aux_channel);
+      #endif
+      break;
+      default:
+      break;
+    }
+
+    OC::DAC::set(dac_channel, sample);
+    OC::DAC::set(aux_channel, aux_sample);
+
+    if (triggered || (continuous && changed)) {
+      scrolling_history_.Push(history_sample);
+      trigger_display_.Update(1, true);
+    } else {
+      trigger_display_.Update(1, false);
+    }
+    scrolling_history_.Update();
+  }
+
+  // Wrappers for ScaleEdit
+  void scale_changed() {
+    force_update_ = true;
+  }
+
+  uint16_t get_scale_mask(uint8_t scale_select) const {
+    return get_mask(scale_select);
+  }
+
+  void update_scale_mask(uint16_t mask, uint8_t scale_select) {
+
+    switch (scale_select) {
+
+      case SLOT1:
+        apply_value(DQ_CHANNEL_SETTING_MASK1, mask);
+        last_mask_[0] = mask;
+      break;
+      case SLOT2:
+        apply_value(DQ_CHANNEL_SETTING_MASK2, mask);
+        last_mask_[1] = mask;
+      break;
+      case SLOT3:
+        apply_value(DQ_CHANNEL_SETTING_MASK3, mask);
+        last_mask_[2] = mask;
+      break;
+      case SLOT4:
+        apply_value(DQ_CHANNEL_SETTING_MASK4, mask);
+        last_mask_[3] = mask;
+      break;
+      default:
+      break;
+    }
+    force_update_ = true;
+  }
+  //
+
+  uint8_t getTriggerState() const {
+    return trigger_display_.getState();
+  }
+
+  // Maintain an internal list of currently available settings, since some are
+  // dependent on others. It's kind of brute force, but eh, works :) If other
+  // apps have a similar need, it can be moved to a common wrapper
+
+  int num_enabled_settings() const {
+    return num_enabled_settings_;
+  }
+
+  DQ_ChannelSetting enabled_setting_at(int index) const {
+    return enabled_settings_[index];
+  }
+
+  void update_enabled_settings() {
+    DQ_ChannelSetting *settings = enabled_settings_;
+
+    switch(get_scale_select()) {
+
+      case SLOT1:
+      *settings++ = DQ_CHANNEL_SETTING_SCALE1;
+      break;
+      case SLOT2:
+      *settings++ = DQ_CHANNEL_SETTING_SCALE2;
+      break;
+      case SLOT3:
+      *settings++ = DQ_CHANNEL_SETTING_SCALE3;
+      break;
+      case SLOT4:
+      *settings++ = DQ_CHANNEL_SETTING_SCALE4;
+      break;
+      default:
+      break;
+    }
+
+    // to do -- might as well disable no scale
+    if (OC::Scales::SCALE_NONE != get_scale(get_scale_select())) {
+
+      switch(get_scale_select()) {
+
+        case SLOT1:
+         *settings++ = DQ_CHANNEL_SETTING_MASK1;
+        break;
+        case SLOT2:
+         *settings++ = DQ_CHANNEL_SETTING_MASK2;
+        break;
+        case SLOT3:
+         *settings++ = DQ_CHANNEL_SETTING_MASK3;
+        break;
+        case SLOT4:
+         *settings++ = DQ_CHANNEL_SETTING_MASK4;
+        break;
+        default:
+        break;
+      }
+
+      *settings++ = DQ_CHANNEL_SETTING_SEQ_MODE;
+      *settings++ = DQ_CHANNEL_SETTING_SCALE_SEQ;
+
+      switch(get_scale_select()) {
+
+        case SLOT1:
+        *settings++ = DQ_CHANNEL_SETTING_ROOT1;
+        *settings++ = DQ_CHANNEL_SETTING_TRANSPOSE1;
+        break;
+        case SLOT2:
+        *settings++ = DQ_CHANNEL_SETTING_ROOT2;
+        *settings++ = DQ_CHANNEL_SETTING_TRANSPOSE2;
+        break;
+        case SLOT3:
+        *settings++ = DQ_CHANNEL_SETTING_ROOT3;
+        *settings++ = DQ_CHANNEL_SETTING_TRANSPOSE3;
+        break;
+        case SLOT4:
+        *settings++ = DQ_CHANNEL_SETTING_ROOT4;
+        *settings++ = DQ_CHANNEL_SETTING_TRANSPOSE4;
+        break;
+        default:
+        break;
+      }
+    }
+
+    // todo -- item order?
+    *settings++ = DQ_CHANNEL_SETTING_OCTAVE;
+    *settings++ = DQ_CHANNEL_SETTING_SOURCE;
+
+    // CV sources:
+    switch (get_source()) {
+
+      case DQ_CHANNEL_SOURCE_TURING:
+        *settings++ = DQ_CHANNEL_SETTING_TURING_RANGE;
+        *settings++ = DQ_CHANNEL_SETTING_TURING_LENGTH;
+        *settings++ = DQ_CHANNEL_SETTING_TURING_PROB;
+        *settings++ = DQ_CHANNEL_SETTING_TURING_CV_SOURCE;
+        *settings++ = DQ_CHANNEL_SETTING_TURING_TRIG_OUT;
+       break;
+       default:
+       break;
+    }
+
+    *settings++ = DQ_CHANNEL_SETTING_AUX_CV_DEST;
+    *settings++ = DQ_CHANNEL_SETTING_TRIGGER;
+
+    if (get_trigger_source() < DQ_CHANNEL_TRIGGER_CONTINUOUS_UP)
+      *settings++ = DQ_CHANNEL_SETTING_DELAY;
+
+    *settings++ = DQ_CHANNEL_SETTING_AUX_OUTPUT;
+
+    switch(get_aux_mode()) {
+
+      case DQ_GATE:
+        *settings++ = DQ_CHANNEL_SETTING_PULSEWIDTH;
+      break;
+      case DQ_COPY:
+        *settings++ = DQ_CHANNEL_SETTING_AUX_OCTAVE;
+      break;
+      case DQ_ASR:
+        *settings++ = DQ_CHANNEL_SETTING_AUX_OCTAVE;
+      break;
+      default:
+      break;
+    }
+
+    num_enabled_settings_ = settings - enabled_settings_;
+  }
+
+  //
+
+  void RenderScreensaver(weegfx::coord_t x) const;
+
+private:
+  bool force_update_;
+  bool update_asr_;
+  int last_scale_[NUM_SCALE_SLOTS];
+  uint16_t last_mask_[NUM_SCALE_SLOTS];
+  int scale_sequence_cnt_;
+  int active_scale_slot_;
+  int display_scale_slot_;
+  int display_root_;
+  int root_last_;
+  int transpose_last_;
+  int prev_scale_slot_;
+  int8_t scale_advance_;
+  int8_t scale_advance_state_;
+  bool scale_reset_;
+  bool schedule_scale_update_;
+  int32_t schedule_mask_rotate_;
+  int32_t last_sample_;
+  int32_t aux_sample_;
+  int32_t last_aux_sample_;
+  int8_t continuous_offset_;
+  uint8_t prev_pulsewidth_;
+  int8_t prev_destination_;
+  int8_t prev_octave_cv_;
+  int8_t prev_transpose_cv_;
+  int8_t prev_root_cv_;
+  int8_t prev_scale_cv_;
+
+  uint32_t ticks_;
+  uint32_t channel_frequency_in_ticks_;
+  uint32_t pulse_width_in_ticks_;
+
+  util::TriggerDelay<OC::kMaxTriggerDelayTicks> trigger_delay_;
+  braids::Quantizer quantizer_;
+  OC::DigitalInputDisplay trigger_display_;
+
+  // internal CV sources;
+  util::TuringShiftRegister turing_machine_;
+  int8_t turing_display_length_;
+
+  int num_enabled_settings_;
+  DQ_ChannelSetting enabled_settings_[DQ_CHANNEL_SETTING_LAST];
+
+  OC::vfx::ScrollingHistory<int32_t, 5> scrolling_history_;
+
+  bool update_scale(bool force, uint8_t scale_select, int32_t mask_rotate) {
+
+    force_update_ = false;
+    const int scale = get_scale(scale_select);
+    uint16_t mask = get_mask(scale_select);
+
+    if (mask_rotate)
+      mask = OC::ScaleEditor<DQ_QuantizerChannel>::RotateMask(mask, OC::Scales::GetScale(scale).num_notes, mask_rotate);
+
+    if (force || (last_scale_[scale_select] != scale || last_mask_[scale_select] != mask)) {
+      last_scale_[scale_select] = scale;
+      last_mask_[scale_select] = mask;
+      quantizer_.Configure(OC::Scales::GetScale(scale), mask);
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+const char* const dq_seq_scales[] = {
+  "s#1", "s#2", "s#3", "s#4"
+};
+
+const char* const dq_seq_modes[] = {
+  "-", "TR+1", "TR+2", "TR+3"
+};
+
+const char* const dq_aux_outputs[] = {
+  "gate", "copy", "asr"
+};
+
+const char* const dq_aux_cv_dest[] = {
+  "-", "scl#", "root", "oct", "trns", "mask"
+};
+
+const char* const dq_tm_trig_out[] = {
+  "echo", "lsb", "chng"
+};
+
+SETTINGS_DECLARE(DQ_QuantizerChannel, DQ_CHANNEL_SETTING_LAST) {
+  { OC::Scales::SCALE_SEMI, 0, OC::Scales::NUM_SCALES - 1, "scale", OC::scale_names, settings::STORAGE_TYPE_U8 },
+  { OC::Scales::SCALE_SEMI, 0, OC::Scales::NUM_SCALES - 1, "scale", OC::scale_names, settings::STORAGE_TYPE_U8 },
+  { OC::Scales::SCALE_SEMI, 0, OC::Scales::NUM_SCALES - 1, "scale", OC::scale_names, settings::STORAGE_TYPE_U8 },
+  { OC::Scales::SCALE_SEMI, 0, OC::Scales::NUM_SCALES - 1, "scale", OC::scale_names, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 11, "root #1", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 11, "root #2", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 11, "root #3", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 11, "root #4", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 0, 0, NUM_SCALE_SLOTS - 1, "scale #", dq_seq_scales, settings::STORAGE_TYPE_U8 },
+  { 65535, 1, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 },
+  { 65535, 1, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 },
+  { 65535, 1, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 },
+  { 65535, 1, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 },
+  { 0, 0, 3, "seq_mode", dq_seq_modes, settings::STORAGE_TYPE_U4 },
+  { DQ_CHANNEL_SOURCE_CV1, DQ_CHANNEL_SOURCE_CV1, 4, "CV source", OC::Strings::cv_input_names, settings::STORAGE_TYPE_U4 }, /// to do ..
+  { DQ_CHANNEL_TRIGGER_CONTINUOUS_DOWN, 0, DQ_CHANNEL_TRIGGER_LAST - 1, "trigger source", OC::Strings::channel_trigger_sources, settings::STORAGE_TYPE_U8 },
+  { 0, 0, OC::kNumDelayTimes - 1, "--> latency", OC::Strings::trigger_delay_times, settings::STORAGE_TYPE_U8 },
+  { 0, -5, 7, "transpose #1", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -5, 7, "transpose #2", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -5, 7, "transpose #3", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -5, 7, "transpose #4", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -4, 4, "octave", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, 0, DQ_AUX_MODE_LAST-1, "aux.output", dq_aux_outputs, settings::STORAGE_TYPE_U8 },
+  { 25, 0, 255, "--> pw", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, -5, 5, "--> aux +/-", NULL, settings::STORAGE_TYPE_I8 }, // aux octave
+  { 0, 0, DQ_DEST_LAST-1, "CV aux.", dq_aux_cv_dest, settings::STORAGE_TYPE_U8 },
+  { 16, 1, 32, " > LFSR length", NULL, settings::STORAGE_TYPE_U8 },
+  { 128, 0, 255, " > LFSR p", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 3, " > LFSR CV", OC::Strings::TM_aux_cv_destinations, settings::STORAGE_TYPE_U8 }, // ??
+  { 15, 1, 120, " > LFSR range", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, DQ_TRIG_AUX_LAST-1, " > LFSR TRIG", dq_tm_trig_out, settings::STORAGE_TYPE_U8 }
+};
+
+// WIP refactoring to better encapsulate and for possible app interface change
+class DualQuantizer {
+public:
+  void Init() {
+    selected_channel = 0;
+    cursor.Init(DQ_CHANNEL_SETTING_SCALE1, DQ_CHANNEL_SETTING_LAST - 1);
+    scale_editor.Init(true);
+  }
+
+  inline bool editing() const {
+    return cursor.editing();
+  }
+
+  inline int cursor_pos() const {
+    return cursor.cursor_pos();
+  }
+
+  int selected_channel;
+  OC::menu::ScreenCursor<OC::menu::kScreenLines> cursor;
+  OC::ScaleEditor<DQ_QuantizerChannel> scale_editor;
+};
+
+DualQuantizer dq_state;
+DQ_QuantizerChannel dq_quantizer_channels[NUMCHANNELS];
+
+void DQ_init() {
+
+  dq_state.Init();
+  for (size_t i = 0; i < NUMCHANNELS; ++i) {
+    dq_quantizer_channels[i].Init(static_cast<DQ_ChannelSource>(DQ_CHANNEL_SOURCE_CV1 + 2*i), static_cast<DQ_ChannelTriggerSource>(DQ_CHANNEL_TRIGGER_TR1 + 2*i));
+  }
+
+  dq_state.cursor.AdjustEnd(dq_quantizer_channels[0].num_enabled_settings() - 1);
+}
+
+size_t DQ_storageSize() {
+  return NUMCHANNELS * DQ_QuantizerChannel::storageSize();
+}
+
+size_t DQ_save(void *storage) {
+  size_t used = 0;
+  for (size_t i = 0; i < NUMCHANNELS; ++i) {
+    used += dq_quantizer_channels[i].Save(static_cast<char*>(storage) + used);
+  }
+  return used;
+}
+
+size_t DQ_restore(const void *storage) {
+  size_t used = 0;
+  for (size_t i = 0; i < NUMCHANNELS; ++i) {
+    used += dq_quantizer_channels[i].Restore(static_cast<const char*>(storage) + used);
+    //int scale = dq_quantizer_channels[i].get_scale_select();
+    for (size_t j = SLOT1; j < LAST_SLOT; j++) {
+      dq_quantizer_channels[i].update_scale_mask(dq_quantizer_channels[i].get_mask(j), j);
+    }
+    dq_quantizer_channels[i].update_enabled_settings();
+  }
+  dq_state.cursor.AdjustEnd(dq_quantizer_channels[0].num_enabled_settings() - 1);
+  return used;
+}
+
+void DQ_handleAppEvent(OC::AppEvent event) {
+  switch (event) {
+    case OC::APP_EVENT_RESUME:
+      dq_state.cursor.set_editing(false);
+      dq_state.scale_editor.Close();
+      break;
+    case OC::APP_EVENT_SUSPEND:
+    case OC::APP_EVENT_SCREENSAVER_ON:
+    case OC::APP_EVENT_SCREENSAVER_OFF:
+      break;
+  }
+}
+
+void DQ_isr() {
+
+  uint32_t triggers = OC::DigitalInputs::clocked();
+
+  dq_quantizer_channels[0].Update(triggers, DAC_CHANNEL_A, DAC_CHANNEL_C);
+  dq_quantizer_channels[1].Update(triggers, DAC_CHANNEL_B, DAC_CHANNEL_D);
+}
+
+void DQ_loop() {
+}
+
+void DQ_menu() {
+
+  OC::menu::DualTitleBar::Draw();
+
+  for (int i = 0, x = 0; i < NUMCHANNELS; ++i, x += 21) {
+
+    const DQ_QuantizerChannel &channel = dq_quantizer_channels[i];
+    OC::menu::DualTitleBar::SetColumn(i);
+    OC::menu::DualTitleBar::DrawGateIndicator(i, channel.getTriggerState());
+
+    graphics.movePrintPos(5, 0);
+    graphics.print((char)('A' + i));
+    graphics.movePrintPos(2, 0);
+    graphics.print('#');
+    graphics.print(channel.get_display_scale() + 1);
+    graphics.movePrintPos(12, 0);
+    if (channel.get_aux_cv_dest() == DQ_DEST_ROOT)
+      graphics.print(OC::Strings::note_names[channel.get_display_root()]);
+    else
+      graphics.print(OC::Strings::note_names[channel.get_root(channel.get_display_scale())]);
+    int octave = channel.get_octave();
+    if (octave)
+      graphics.pretty_print(octave);
+  }
+  OC::menu::DualTitleBar::Selected(dq_state.selected_channel);
+
+
+  const DQ_QuantizerChannel &channel = dq_quantizer_channels[dq_state.selected_channel];
+
+  OC::menu::SettingsList<OC::menu::kScreenLines, 0, OC::menu::kDefaultValueX> settings_list(dq_state.cursor);
+  OC::menu::SettingsListItem list_item;
+  while (settings_list.available()) {
+    const int setting =
+        channel.enabled_setting_at(settings_list.Next(list_item));
+    const int value = channel.get_value(setting);
+    const settings::value_attr &attr = DQ_QuantizerChannel::value_attr(setting);
+
+    switch (setting) {
+      case DQ_CHANNEL_SETTING_SCALE1:
+      case DQ_CHANNEL_SETTING_SCALE2:
+      case DQ_CHANNEL_SETTING_SCALE3:
+      case DQ_CHANNEL_SETTING_SCALE4:
+        list_item.SetPrintPos();
+        if (list_item.editing) {
+          OC::menu::DrawEditIcon(6, list_item.y, value, attr);
+          graphics.movePrintPos(6, 0);
+        }
+        graphics.print(OC::scale_names[value]);
+        list_item.DrawCustom();
+        break;
+      case DQ_CHANNEL_SETTING_MASK1:
+      case DQ_CHANNEL_SETTING_MASK2:
+      case DQ_CHANNEL_SETTING_MASK3:
+      case DQ_CHANNEL_SETTING_MASK4:
+        OC::menu::DrawMask<false, 16, 8, 1>(OC::menu::kDisplayWidth, list_item.y, channel.get_rotated_mask(channel.get_display_scale()), OC::Scales::GetScale(channel.get_scale(channel.get_display_scale())).num_notes);
+        list_item.DrawNoValue<false>(value, attr);
+        break;
+      case DQ_CHANNEL_SETTING_TRIGGER:
+      {
+        if (channel.get_source() > DQ_CHANNEL_SOURCE_CV4)
+           list_item.DrawValueMax(value, attr, DQ_CHANNEL_TRIGGER_TR4);
+        else
+          list_item.DrawDefault(value, attr);
+      }
+      break;
+      case DQ_CHANNEL_SETTING_SOURCE:
+      {
+      if (channel.get_source() == DQ_CHANNEL_SOURCE_TURING) {
+
+          int turing_length = channel.get_turing_display_length();
+          int w = turing_length >= 16 ? 16 * 3 : turing_length * 3;
+
+          OC::menu::DrawMask<true, 16, 8, 1>(OC::menu::kDisplayWidth, list_item.y, channel.get_shift_register(), turing_length);
+          list_item.valuex = OC::menu::kDisplayWidth - w - 1;
+          list_item.DrawNoValue<true>(value, attr);
+       }
+       else if (channel.get_trigger_source() > DQ_CHANNEL_TRIGGER_TR4)
+          list_item.DrawValueMax(value, attr, DQ_CHANNEL_SOURCE_CV4);
+       else
+          list_item.DrawDefault(value, attr);
+      }
+      break;
+      case DQ_CHANNEL_SETTING_PULSEWIDTH:
+        list_item.Draw_PW_Value(value, attr);
+      break;
+      default:
+        list_item.DrawDefault(value, attr);
+      break;
+    }
+  }
+
+  if (dq_state.scale_editor.active())
+    dq_state.scale_editor.Draw();
+}
+
+void DQ_handleButtonEvent(const UI::Event &event) {
+
+  if (UI::EVENT_BUTTON_LONG_PRESS == event.type && OC::CONTROL_BUTTON_DOWN == event.control)
+    DQ_downButtonLong();
+
+  if (dq_state.scale_editor.active()) {
+    dq_state.scale_editor.HandleButtonEvent(event);
+    return;
+  }
+
+  if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        DQ_topButton();
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        DQ_lowerButton();
+        break;
+      case OC::CONTROL_BUTTON_L:
+        DQ_leftButton();
+        break;
+      case OC::CONTROL_BUTTON_R:
+        DQ_rightButton();
+        break;
+    }
+  } else {
+    if (OC::CONTROL_BUTTON_L == event.control)
+      DQ_leftButtonLong();
+  }
+}
+
+void DQ_handleEncoderEvent(const UI::Event &event) {
+  if (dq_state.scale_editor.active()) {
+    dq_state.scale_editor.HandleEncoderEvent(event);
+    return;
+  }
+
+  if (OC::CONTROL_ENCODER_L == event.control) {
+
+    int selected_channel = dq_state.selected_channel + event.value;
+    CONSTRAIN(selected_channel, 0, NUMCHANNELS - 0x1);
+    dq_state.selected_channel = selected_channel;
+
+    DQ_QuantizerChannel &selected = dq_quantizer_channels[dq_state.selected_channel];
+    selected.update_enabled_settings();
+    dq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+    //??
+    dq_state.cursor.Scroll(0x0);
+
+  } else if (OC::CONTROL_ENCODER_R == event.control) {
+
+    DQ_QuantizerChannel &selected = dq_quantizer_channels[dq_state.selected_channel];
+
+    if (dq_state.editing()) {
+
+      DQ_ChannelSetting setting = selected.enabled_setting_at(dq_state.cursor_pos());
+      if (DQ_CHANNEL_SETTING_MASK1 != setting || DQ_CHANNEL_SETTING_MASK2 != setting || DQ_CHANNEL_SETTING_MASK3 != setting || DQ_CHANNEL_SETTING_MASK4 != setting) {
+
+        int event_value = event.value;
+
+        // hack disable internal sources when mode = continuous:
+        switch (setting) {
+
+          case DQ_CHANNEL_SETTING_TRIGGER:
+          {
+            if (selected.get_trigger_source() == DQ_CHANNEL_TRIGGER_TR4 && selected.get_source() > DQ_CHANNEL_SOURCE_CV4 && event_value > 0)
+              event_value = 0x0;
+          }
+          break;
+          case DQ_CHANNEL_SETTING_SOURCE:
+          {
+             if (selected.get_source() == DQ_CHANNEL_SOURCE_CV4 && selected.get_trigger_source() > DQ_CHANNEL_TRIGGER_TR4 && event_value > 0)
+              event_value = 0x0;
+          }
+          break;
+          default:
+          break;
+        }
+
+        if (selected.change_value(setting, event_value))
+          selected.force_update();
+
+        switch (setting) {
+          case DQ_CHANNEL_SETTING_SCALE1:
+          case DQ_CHANNEL_SETTING_SCALE2:
+          case DQ_CHANNEL_SETTING_SCALE3:
+          case DQ_CHANNEL_SETTING_SCALE4:
+          case DQ_CHANNEL_SETTING_TRIGGER:
+          case DQ_CHANNEL_SETTING_SOURCE:
+          case DQ_CHANNEL_SETTING_AUX_OUTPUT:
+            selected.update_enabled_settings();
+            dq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+          break;
+          case DQ_CHANNEL_SETTING_SCALE_SEQ:
+          case DQ_CHANNEL_SETTING_SEQ_MODE:
+            selected.update_enabled_settings();
+            dq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+            selected.reset_scale();
+          break;
+          default:
+          break;
+        }
+      }
+    } else {
+      dq_state.cursor.Scroll(event.value);
+    }
+  }
+}
+
+void DQ_topButton() {
+  DQ_QuantizerChannel &selected = dq_quantizer_channels[dq_state.selected_channel];
+  if (selected.change_value(DQ_CHANNEL_SETTING_OCTAVE, 1)) {
+    selected.force_update();
+  }
+}
+
+void DQ_lowerButton() {
+  DQ_QuantizerChannel &selected = dq_quantizer_channels[dq_state.selected_channel];
+  if (selected.change_value(DQ_CHANNEL_SETTING_OCTAVE, -1)) {
+    selected.force_update();
+  }
+}
+
+void DQ_rightButton() {
+  DQ_QuantizerChannel &selected = dq_quantizer_channels[dq_state.selected_channel];
+  switch (selected.enabled_setting_at(dq_state.cursor_pos())) {
+    case DQ_CHANNEL_SETTING_MASK1:
+    case DQ_CHANNEL_SETTING_MASK2:
+    case DQ_CHANNEL_SETTING_MASK3:
+    case DQ_CHANNEL_SETTING_MASK4: {
+      int scale = selected.get_scale(selected.get_scale_select());
+      if (OC::Scales::SCALE_NONE != scale) {
+        dq_state.scale_editor.Edit(&selected, scale);
+      }
+    }
+    break;
+    default:
+      dq_state.cursor.toggle_editing();
+      break;
+  }
+}
+
+void DQ_leftButton() {
+  dq_state.selected_channel = (dq_state.selected_channel + 1) & 1u;
+  DQ_QuantizerChannel &selected = dq_quantizer_channels[dq_state.selected_channel];
+  dq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+}
+
+void DQ_leftButtonLong() {
+
+  // copy scale settings to all slots:
+  DQ_QuantizerChannel &selected_channel = dq_quantizer_channels[dq_state.selected_channel];
+  int _slot = selected_channel.get_scale_select();
+  int scale = selected_channel.get_scale(_slot);
+  int mask = selected_channel.get_mask(_slot);
+  int root = selected_channel.get_root(_slot);
+  int transpose = selected_channel.get_transpose(_slot);
+
+  for (int i = 0; i < NUM_SCALE_SLOTS; ++i) {
+    for (int j = 0; j < NUMCHANNELS; ++j)
+      dq_quantizer_channels[j].set_scale_at_slot(scale, mask, root, transpose, i);
+  }
+}
+
+void DQ_downButtonLong() {
+  // reset mask
+  DQ_QuantizerChannel &selected_channel = dq_quantizer_channels[dq_state.selected_channel];
+  int scale_slot = selected_channel.get_scale_select();
+  selected_channel.set_scale_at_slot(selected_channel.get_scale(scale_slot), 0xFFFF, selected_channel.get_root(scale_slot), selected_channel.get_transpose(scale_slot), scale_slot);
+}
+
+int32_t dq_history[5];
+static const weegfx::coord_t dq_kBottom = 60;
+
+inline int32_t dq_render_pitch(int32_t pitch, weegfx::coord_t x, weegfx::coord_t width) {
+  CONSTRAIN(pitch, 0, 120 << 7);
+  int32_t octave = pitch / (12 << 7);
+  pitch -= (octave * 12 << 7);
+  graphics.drawHLine(x, dq_kBottom - ((pitch * 4) >> 7), width << 1);
+  return octave;
+}
+
+void DQ_QuantizerChannel::RenderScreensaver(weegfx::coord_t start_x) const {
+
+  // History
+  scrolling_history_.Read(dq_history);
+  weegfx::coord_t scroll_pos = (scrolling_history_.get_scroll_pos() * 6) >> 8;
+
+  // Top: Show gate & CV (or register bits)
+  OC::menu::DrawGateIndicator(start_x + 1, 2, getTriggerState());
+  const DQ_ChannelSource source = get_source();
+
+  switch (source) {
+    case DQ_CHANNEL_SOURCE_TURING:
+      OC::menu::DrawMask<true, 16, 8, 1>(start_x + 58, 1, get_shift_register(), get_turing_display_length());
+      break;
+    default: {
+      graphics.setPixel(start_x + DQ_OFFSET_X - 16, 4);
+      int32_t cv = OC::ADC::value(static_cast<ADC_CHANNEL>(source));
+      cv = (cv * 20 + 2047) >> 11;
+      if (cv < 0)
+        graphics.drawRect(start_x + DQ_OFFSET_X - 16 + cv, 6, -cv, 2);
+      else if (cv > 0)
+        graphics.drawRect(start_x + DQ_OFFSET_X - 16, 6, cv, 2);
+      else
+        graphics.drawRect(start_x + DQ_OFFSET_X - 16, 6, 1, 2);
+    }
+    break;
+  }
+
+#ifdef DQ_DEBUG_SCREENSAVER
+  graphics.drawVLinePattern(start_x + 56, 0, 64, 0x55);
+#endif
+
+  // Draw semitone intervals, 4px apart
+  weegfx::coord_t x = start_x + 56;
+  weegfx::coord_t y = dq_kBottom;
+  for (int i = 0; i < 12; ++i, y -= 4)
+    graphics.setPixel(x, y);
+
+  x = start_x + 1;
+  dq_render_pitch(dq_history[0], x, scroll_pos); x += scroll_pos;
+  dq_render_pitch(dq_history[1], x, 6); x += 6;
+  dq_render_pitch(dq_history[2], x, 6); x += 6;
+  dq_render_pitch(dq_history[3], x, 6); x += 6;
+
+  int32_t octave = dq_render_pitch(dq_history[4], x, 6 - scroll_pos);
+  graphics.drawBitmap8(start_x + 58, dq_kBottom - octave * 4 - 1, OC::kBitmapLoopMarkerW, OC::bitmap_loop_markers_8 + OC::kBitmapLoopMarkerW);
+}
+
+void DQ_screensaver() {
+#ifdef DQ_DEBUG_SCREENSAVER
+  debug::CycleMeasurement render_cycles;
+#endif
+
+  dq_quantizer_channels[0].RenderScreensaver(0);
+  dq_quantizer_channels[1].RenderScreensaver(64);
+
+#ifdef DQ_DEBUG_SCREENSAVER
+  graphics.drawHLine(0, menu::kMenuLineH, menu::kDisplayWidth);
+  uint32_t us = debug::cycles_to_us(render_cycles.read());
+  graphics.setPrintPos(0, 32);
+  graphics.printf("%u",  us);
+#endif
+}

--- a/software/o_c_REV/APP_DQ.ino
+++ b/software/o_c_REV/APP_DQ.ino
@@ -26,6 +26,8 @@
 // from Braids by Olivier Gillet (see braids_quantizer.h/cc et al.). It has since
 // grown a little bit...
 
+#ifdef ENABLE_APP_METAQ
+
 #include "OC_apps.h"
 #include "util/util_settings.h"
 #include "util/util_trigger_delay.h"
@@ -1568,3 +1570,5 @@ void DQ_screensaver() {
   graphics.printf("%u",  us);
 #endif
 }
+
+#endif // ENABLE_APP_METAQ

--- a/software/o_c_REV/APP_QQ.ino
+++ b/software/o_c_REV/APP_QQ.ino
@@ -25,6 +25,8 @@
 // from Braids by Olivier Gillet (see braids_quantizer.h/cc et al.). It has since
 // grown a little bit...
 
+#ifdef ENABLE_APP_QUANTERMAIN
+
 #include "OC_apps.h"
 #include "util/util_logistic_map.h"
 #include "util/util_settings.h"
@@ -1576,3 +1578,5 @@ void QQ_debug() {
  }
 }
 #endif // QQ_DEBUG
+
+#endif // ENABLE_APP_QUANTERMAIN

--- a/software/o_c_REV/APP_QQ.ino
+++ b/software/o_c_REV/APP_QQ.ino
@@ -1,0 +1,1578 @@
+// Copyright (c) 2015, 2016 Patrick Dowling, Tim Churches
+//
+// Initial app implementation: Patrick Dowling (pld@gurkenkiste.com)
+// Modifications by: Tim Churches (tim.churches@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Quad quantizer app, based around the the quantizer/scales implementation from
+// from Braids by Olivier Gillet (see braids_quantizer.h/cc et al.). It has since
+// grown a little bit...
+
+#include "OC_apps.h"
+#include "util/util_logistic_map.h"
+#include "util/util_settings.h"
+#include "util/util_trigger_delay.h"
+#include "util/util_turing.h"
+#include "util/util_integer_sequences.h"
+#include "peaks_bytebeat.h"
+#include "braids_quantizer.h"
+#include "braids_quantizer_scales.h"
+#include "OC_menus.h"
+#include "OC_scales.h"
+#include "OC_scale_edit.h"
+#include "OC_strings.h"
+
+// unsigned long LAST_REDRAW_TIME = 0;
+extern uint_fast8_t MENU_REDRAW;
+// OC::UiMode ui_mode = OC::UI_MODE_MENU;
+
+#ifdef BUCHLA_4U
+ #define QQ_OFFSET_X 20
+#else
+ #define QQ_OFFSET_X 31
+#endif
+
+void QQ_downButtonLong();
+void QQ_topButton();
+void QQ_lowerButton();
+void QQ_leftButton();
+void QQ_rightButton();
+void QQ_leftButtonLong();
+
+enum ChannelSetting {
+  CHANNEL_SETTING_SCALE,
+  CHANNEL_SETTING_ROOT,
+  CHANNEL_SETTING_MASK,
+  CHANNEL_SETTING_SOURCE,
+  CHANNEL_SETTING_AUX_SOURCE_DEST,
+  CHANNEL_SETTING_TRIGGER,
+  CHANNEL_SETTING_CLKDIV,
+  CHANNEL_SETTING_DELAY,
+  CHANNEL_SETTING_TRANSPOSE,
+  CHANNEL_SETTING_OCTAVE,
+  CHANNEL_SETTING_FINE,
+  CHANNEL_SETTING_TURING_LENGTH,
+  CHANNEL_SETTING_TURING_PROB,
+  CHANNEL_SETTING_TURING_MODULUS,
+  CHANNEL_SETTING_TURING_RANGE,
+  CHANNEL_SETTING_TURING_PROB_CV_SOURCE,
+  CHANNEL_SETTING_TURING_MODULUS_CV_SOURCE,
+  CHANNEL_SETTING_TURING_RANGE_CV_SOURCE,
+  CHANNEL_SETTING_LOGISTIC_MAP_R,
+  CHANNEL_SETTING_LOGISTIC_MAP_RANGE,
+  CHANNEL_SETTING_LOGISTIC_MAP_R_CV_SOURCE,
+  CHANNEL_SETTING_LOGISTIC_MAP_RANGE_CV_SOURCE,
+  CHANNEL_SETTING_BYTEBEAT_EQUATION,
+  CHANNEL_SETTING_BYTEBEAT_RANGE,
+  CHANNEL_SETTING_BYTEBEAT_P0,
+  CHANNEL_SETTING_BYTEBEAT_P1,
+  CHANNEL_SETTING_BYTEBEAT_P2,
+  CHANNEL_SETTING_BYTEBEAT_EQUATION_CV_SOURCE,
+  CHANNEL_SETTING_BYTEBEAT_RANGE_CV_SOURCE,
+  CHANNEL_SETTING_BYTEBEAT_P0_CV_SOURCE,
+  CHANNEL_SETTING_BYTEBEAT_P1_CV_SOURCE,
+  CHANNEL_SETTING_BYTEBEAT_P2_CV_SOURCE,
+  CHANNEL_SETTING_INT_SEQ_INDEX,
+  CHANNEL_SETTING_INT_SEQ_MODULUS,
+  CHANNEL_SETTING_INT_SEQ_RANGE,
+  CHANNEL_SETTING_INT_SEQ_DIRECTION,
+  CHANNEL_SETTING_INT_SEQ_BROWNIAN_PROB,
+  CHANNEL_SETTING_INT_SEQ_LOOP_START,
+  CHANNEL_SETTING_INT_SEQ_LOOP_LENGTH,
+  CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_PROB,
+  CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_RANGE,
+  CHANNEL_SETTING_INT_SEQ_STRIDE,
+  CHANNEL_SETTING_INT_SEQ_INDEX_CV_SOURCE,
+  CHANNEL_SETTING_INT_SEQ_MODULUS_CV_SOURCE,
+  CHANNEL_SETTING_INT_SEQ_RANGE_CV_SOURCE,
+  CHANNEL_SETTING_INT_SEQ_STRIDE_CV_SOURCE,
+  CHANNEL_SETTING_INT_SEQ_RESET_TRIGGER,
+  CHANNEL_SETTING_LAST
+};
+
+enum ChannelTriggerSource {
+  CHANNEL_TRIGGER_TR1,
+  CHANNEL_TRIGGER_TR2,
+  CHANNEL_TRIGGER_TR3,
+  CHANNEL_TRIGGER_TR4,
+  CHANNEL_TRIGGER_CONTINUOUS_UP,
+  CHANNEL_TRIGGER_CONTINUOUS_DOWN,
+  CHANNEL_TRIGGER_LAST
+};
+
+enum ChannelSource {
+  CHANNEL_SOURCE_CV1,
+  CHANNEL_SOURCE_CV2,
+  CHANNEL_SOURCE_CV3,
+  CHANNEL_SOURCE_CV4,
+  CHANNEL_SOURCE_TURING,
+  CHANNEL_SOURCE_LOGISTIC_MAP,
+  CHANNEL_SOURCE_BYTEBEAT,
+  CHANNEL_SOURCE_INT_SEQ,
+  CHANNEL_SOURCE_LAST
+};
+
+enum QQ_CV_DEST {
+  QQ_DEST_NONE,
+  QQ_DEST_ROOT,
+  QQ_DEST_OCTAVE,
+  QQ_DEST_TRANSPOSE,
+  QQ_DEST_MASK,
+  QQ_DEST_LAST
+};
+
+class QuantizerChannel : public settings::SettingsBase<QuantizerChannel, CHANNEL_SETTING_LAST> {
+public:
+
+  int get_scale(uint8_t dummy) const {
+    return values_[CHANNEL_SETTING_SCALE];
+  }
+
+  void set_scale(int scale) {
+    if (scale != get_scale(DUMMY)) {
+      const OC::Scale &scale_def = OC::Scales::GetScale(scale);
+      uint16_t mask = get_mask();
+      if (0 == (mask & ~(0xffff << scale_def.num_notes)))
+        mask |= 0x1;
+      apply_value(CHANNEL_SETTING_MASK, mask);
+      apply_value(CHANNEL_SETTING_SCALE, scale);
+    }
+  }
+
+  // dummy
+  int get_scale_select() const {
+    return 0;
+  }
+
+  // dummy
+  void set_scale_at_slot(int scale, uint16_t mask, int root, int transpose, uint8_t scale_slot) {
+
+  }
+
+  // dummy
+  int get_transpose(uint8_t DUMMY) const {
+    return 0;
+  }
+
+  int get_root() const {
+    return values_[CHANNEL_SETTING_ROOT];
+  }
+
+  int get_root(uint8_t DUMMY) const {
+    return 0x0;
+  }
+
+  uint16_t get_mask() const {
+    return values_[CHANNEL_SETTING_MASK];
+  }
+
+  uint16_t get_rotated_scale_mask() const {
+    return last_mask_;
+  }
+
+  ChannelSource get_source() const {
+    return static_cast<ChannelSource>(values_[CHANNEL_SETTING_SOURCE]);
+  }
+
+  ChannelTriggerSource get_trigger_source() const {
+    return static_cast<ChannelTriggerSource>(values_[CHANNEL_SETTING_TRIGGER]);
+  }
+
+  uint8_t get_channel_index() const {
+    return channel_index_;
+  }
+
+  uint8_t get_clkdiv() const {
+    return values_[CHANNEL_SETTING_CLKDIV];
+  }
+
+  uint16_t get_trigger_delay() const {
+    return values_[CHANNEL_SETTING_DELAY];
+  }
+
+  int get_transpose() const {
+    return values_[CHANNEL_SETTING_TRANSPOSE];
+  }
+
+  int get_octave() const {
+    return values_[CHANNEL_SETTING_OCTAVE];
+  }
+
+  int get_fine() const {
+    return values_[CHANNEL_SETTING_FINE];
+  }
+
+  uint8_t get_aux_cv_dest() const {
+    return values_[CHANNEL_SETTING_AUX_SOURCE_DEST];
+  }
+
+  uint8_t get_turing_length() const {
+    return values_[CHANNEL_SETTING_TURING_LENGTH];
+  }
+
+  uint8_t get_turing_prob() const {
+    return values_[CHANNEL_SETTING_TURING_PROB];
+  }
+
+  uint8_t get_turing_modulus() const {
+    return values_[CHANNEL_SETTING_TURING_MODULUS];
+  }
+
+  uint8_t get_turing_range() const {
+    return values_[CHANNEL_SETTING_TURING_RANGE];
+  }
+
+  uint8_t get_turing_prob_cv_source() const {
+    return values_[CHANNEL_SETTING_TURING_PROB_CV_SOURCE];
+  }
+
+  uint8_t get_turing_modulus_cv_source() const {
+    return values_[CHANNEL_SETTING_TURING_MODULUS_CV_SOURCE];
+  }
+
+  uint8_t get_turing_range_cv_source() const {
+    return values_[CHANNEL_SETTING_TURING_RANGE_CV_SOURCE];
+  }
+
+  uint8_t get_logistic_map_r() const {
+    return values_[CHANNEL_SETTING_LOGISTIC_MAP_R];
+  }
+
+  uint8_t get_logistic_map_range() const {
+    return values_[CHANNEL_SETTING_LOGISTIC_MAP_RANGE];
+  }
+
+  uint8_t get_logistic_map_r_cv_source() const {
+    return values_[CHANNEL_SETTING_LOGISTIC_MAP_R_CV_SOURCE];
+  }
+
+  uint8_t get_logistic_map_range_cv_source() const {
+    return values_[CHANNEL_SETTING_LOGISTIC_MAP_RANGE_CV_SOURCE];
+  }
+
+  uint8_t get_bytebeat_equation() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_EQUATION];
+  }
+
+  uint8_t get_bytebeat_range() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_RANGE];
+  }
+
+  uint8_t get_bytebeat_p0() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_P0];
+  }
+
+  uint8_t get_bytebeat_p1() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_P1];
+  }
+
+  uint8_t get_bytebeat_p2() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_P2];
+  }
+
+  uint8_t get_bytebeat_equation_cv_source() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_EQUATION_CV_SOURCE];
+  }
+
+  uint8_t get_bytebeat_range_cv_source() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_RANGE_CV_SOURCE];
+  }
+
+  uint8_t get_bytebeat_p0_cv_source() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_P0_CV_SOURCE];
+  }
+
+  uint8_t get_bytebeat_p1_cv_source() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_P1_CV_SOURCE];
+  }
+
+  uint8_t get_bytebeat_p2_cv_source() const {
+    return values_[CHANNEL_SETTING_BYTEBEAT_P2_CV_SOURCE];
+  }
+
+  uint8_t get_int_seq_index() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_INDEX];
+  }
+
+  uint8_t get_int_seq_modulus() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_MODULUS];
+  }
+
+  uint8_t get_int_seq_range() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_RANGE];
+  }
+
+  int16_t get_int_seq_start() const {
+    return static_cast<int16_t>(values_[CHANNEL_SETTING_INT_SEQ_LOOP_START]);
+  }
+
+  void set_int_seq_start(uint8_t start_pos) {
+    values_[CHANNEL_SETTING_INT_SEQ_LOOP_START] = start_pos;
+  }
+
+  int16_t get_int_seq_length() const {
+    return static_cast<int16_t>(values_[CHANNEL_SETTING_INT_SEQ_LOOP_LENGTH] - 1);
+  }
+
+  bool get_int_seq_dir() const {
+    return static_cast<bool>(values_[CHANNEL_SETTING_INT_SEQ_DIRECTION]);
+  }
+
+  int16_t get_int_seq_brownian_prob() const {
+    return static_cast<int16_t>(values_[CHANNEL_SETTING_INT_SEQ_BROWNIAN_PROB]);
+  }
+
+  uint8_t get_int_seq_index_cv_source() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_INDEX_CV_SOURCE];
+  }
+
+  uint8_t get_int_seq_modulus_cv_source() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_MODULUS_CV_SOURCE];
+  }
+
+  uint8_t get_int_seq_range_cv_source() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_RANGE_CV_SOURCE];
+  }
+
+  uint8_t get_int_seq_frame_shift_prob() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_PROB];
+  }
+
+  uint8_t get_int_seq_frame_shift_range() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_RANGE];
+  }
+
+  uint8_t get_int_seq_stride() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_STRIDE];
+  }
+
+  uint8_t get_int_seq_stride_cv_source() const {
+    return values_[CHANNEL_SETTING_INT_SEQ_STRIDE_CV_SOURCE];
+  }
+
+  ChannelTriggerSource get_int_seq_reset_trigger_source() const {
+    return static_cast<ChannelTriggerSource>(values_[CHANNEL_SETTING_INT_SEQ_RESET_TRIGGER]);
+  }
+
+  void clear_dest() {
+    // ...
+    schedule_mask_rotate_ = 0x0;
+    continuous_offset_ = 0x0;
+    prev_transpose_cv_ = 0x0;
+    prev_transpose_cv_ = 0x0;
+    prev_root_cv_ = 0x0;
+  }
+
+  void Init(ChannelSource source, ChannelTriggerSource trigger_source) {
+    InitDefaults();
+    apply_value(CHANNEL_SETTING_SOURCE, source);
+    apply_value(CHANNEL_SETTING_TRIGGER, trigger_source);
+
+    channel_index_ = source;
+    force_update_ = true;
+    instant_update_ = false;
+    last_scale_ = -1;
+    last_mask_ = 0;
+    last_sample_ = 0;
+    clock_ = 0;
+    int_seq_reset_ = false;
+    continuous_offset_ = false;
+    schedule_mask_rotate_ = false;
+    prev_octave_cv_ = 0;
+    prev_transpose_cv_ = 0;
+    prev_root_cv_ = 0;
+    prev_destination_ = 0;
+
+    trigger_delay_.Init();
+    turing_machine_.Init();
+    logistic_map_.Init();
+    bytebeat_.Init();
+    int_seq_.Init(get_int_seq_start(), get_int_seq_length());
+    quantizer_.Init();
+    update_scale(true, false);
+    trigger_display_.Init();
+    update_enabled_settings();
+
+    scrolling_history_.Init(OC::DAC::kOctaveZero * 12 << 7);
+  }
+
+  void force_update() {
+    force_update_ = true;
+  }
+
+  void instant_update() {
+    instant_update_ = (~instant_update_) & 1u;
+  }
+
+  inline void Update(uint32_t triggers, DAC_CHANNEL dac_channel) {
+
+    uint8_t index = channel_index_;
+
+    ChannelSource source = get_source();
+    ChannelTriggerSource trigger_source = get_trigger_source();
+    bool continuous = CHANNEL_TRIGGER_CONTINUOUS_UP == trigger_source || CHANNEL_TRIGGER_CONTINUOUS_DOWN == trigger_source;
+    bool triggered = !continuous &&
+      (triggers & DIGITAL_INPUT_MASK(trigger_source - CHANNEL_TRIGGER_TR1));
+
+    if (source == CHANNEL_SOURCE_INT_SEQ) {
+      ChannelTriggerSource int_seq_reset_trigger_source = get_int_seq_reset_trigger_source() ;
+      int_seq_reset_ = (triggers & DIGITAL_INPUT_MASK(int_seq_reset_trigger_source - 1));
+    }
+
+    trigger_delay_.Update();
+    if (triggered)
+      trigger_delay_.Push(OC::trigger_delay_ticks[get_trigger_delay()]);
+    triggered = trigger_delay_.triggered();
+
+    if (triggered) {
+      ++clock_;
+      if (clock_ >= get_clkdiv()) {
+        clock_ = 0;
+      } else {
+        triggered = false;
+      }
+    }
+
+    bool update = continuous || triggered;
+
+    if (update)
+      update_scale(force_update_, schedule_mask_rotate_);
+
+    int32_t sample = last_sample_;
+    int32_t temp_sample = 0;
+    int32_t history_sample = 0;
+
+
+    switch (source) {
+      case CHANNEL_SOURCE_TURING: {
+          // this doesn't make sense when continuously quantizing; should be hidden via the menu ...
+          if (continuous)
+            break;
+
+          turing_machine_.set_length(get_turing_length());
+          int32_t probability = get_turing_prob();
+          if (get_turing_prob_cv_source()) {
+            probability += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_turing_prob_cv_source() - 1)) + 7) >> 4;
+            CONSTRAIN(probability, 0, 255);
+          }
+          turing_machine_.set_probability(probability);
+          if (triggered) {
+            uint32_t shift_register = turing_machine_.Clock();
+            uint8_t range = get_turing_range();
+            if (get_turing_range_cv_source()) {
+              range += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_turing_range_cv_source() - 1)) + 15) >> 5;
+              CONSTRAIN(range, 1, 120);
+            }
+
+            if (quantizer_.enabled()) {
+
+              uint8_t modulus = get_turing_modulus();
+              if (get_turing_modulus_cv_source()) {
+                 modulus += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_turing_modulus_cv_source() - 1)) + 15) >> 5;
+                 CONSTRAIN(modulus, 2, 121);
+              }
+
+              // Since our range is limited anyway, just grab the last byte for lengths > 8,
+              // otherwise scale to use bits. And apply the modulus
+              uint32_t shift = turing_machine_.length();
+              uint32_t scaled = (shift_register & 0xff) * range;
+              scaled = (scaled >> (shift > 7 ? 8 : shift)) % modulus;
+
+              // The quantizer uses a lookup codebook with 128 entries centered
+              // about 0, so we use the range/scaled output to lookup a note
+              // directly instead of changing to pitch first.
+              int32_t pitch =
+                  quantizer_.Lookup(64 + range / 2 - scaled + get_transpose()) + (get_root() << 7);
+              sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, pitch, get_octave(), OC::DAC::get_voltage_scaling(dac_channel));
+              history_sample = pitch + ((OC::DAC::kOctaveZero + get_octave()) * 12 << 7);
+            } else {
+              // Scale range by 128, so 12 steps = 1V
+              // We dont' need a calibrated value here, really.
+              uint32_t scaled = multiply_u32xu32_rshift(range << 7, shift_register, get_turing_length());
+              scaled += get_transpose() << 7;
+              sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, scaled, get_octave(), OC::DAC::get_voltage_scaling(dac_channel));
+              history_sample = scaled + ((OC::DAC::kOctaveZero + get_octave()) * 12 << 7);
+             }
+          }
+        }
+        break;
+      case CHANNEL_SOURCE_BYTEBEAT: {
+           // this doesn't make sense when continuously quantizing; should be hidden via the menu ...
+            if (continuous)
+              break;
+
+            int32_t bytebeat_eqn = get_bytebeat_equation() << 12;
+            if (get_bytebeat_equation_cv_source()) {
+              bytebeat_eqn += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_bytebeat_equation_cv_source() - 1)) << 4);
+              bytebeat_eqn = USAT16(bytebeat_eqn);
+            }
+            bytebeat_.set_equation(bytebeat_eqn);
+
+            int32_t bytebeat_p0 = get_bytebeat_p0() << 8;
+            if (get_bytebeat_p0_cv_source()) {
+              bytebeat_p0 += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_bytebeat_p0_cv_source() - 1)) << 4);
+              bytebeat_p0 = USAT16(bytebeat_p0);
+            }
+            bytebeat_.set_p0(bytebeat_p0);
+
+            int32_t bytebeat_p1 = get_bytebeat_p1() << 8;
+            if (get_bytebeat_p1_cv_source()) {
+              bytebeat_p1 += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_bytebeat_p1_cv_source() - 1)) << 4);
+              bytebeat_p1 = USAT16(bytebeat_p1);
+            }
+            bytebeat_.set_p1(bytebeat_p1);
+
+            int32_t bytebeat_p2 = get_bytebeat_p2() << 8;
+            if (get_bytebeat_p2_cv_source()) {
+              bytebeat_p2 += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_bytebeat_p2_cv_source() - 1)) << 4);
+              bytebeat_p2 = USAT16(bytebeat_p2);
+            }
+            bytebeat_.set_p2(bytebeat_p2);
+
+            if (triggered) {
+              uint32_t bb = bytebeat_.Clock();
+              uint8_t range = get_bytebeat_range();
+              if (get_bytebeat_range_cv_source()) {
+                range += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_bytebeat_range_cv_source() - 1)) + 15) >> 5;
+                CONSTRAIN(range, 1, 120);
+              }
+
+              if (quantizer_.enabled()) {
+
+                // Since our range is limited anyway, just grab the last byte
+                uint32_t scaled = ((bb >> 8) * range) >> 8;
+
+                // The quantizer uses a lookup codebook with 128 entries centered
+                // about 0, so we use the range/scaled output to lookup a note
+                // directly instead of changing to pitch first.
+                int32_t pitch =
+                  quantizer_.Lookup(64 + range / 2 - scaled + get_transpose()) + (get_root() << 7);
+                sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, pitch, get_octave(), OC::DAC::get_voltage_scaling(dac_channel));
+                history_sample = pitch + ((OC::DAC::kOctaveZero + get_octave()) * 12 << 7);
+              } else {
+                // We dont' need a calibrated value here, really
+                int octave = get_octave();
+                CONSTRAIN(octave, 0, 6);
+                sample = OC::DAC::get_octave_offset(dac_channel, octave) + (get_transpose() << 7);
+                // range is actually 120 (10 oct) but 65535 / 128 is close enough
+                sample += multiply_u32xu32_rshift32((static_cast<uint32_t>(range) * 65535U) >> 7, bb << 16);
+                sample = USAT16(sample);
+                history_sample = sample;
+              }
+            }
+          }
+          break;
+      case CHANNEL_SOURCE_LOGISTIC_MAP: {
+          // this doesn't make sense when continuously quantizing; should be hidden via the menu ...
+          if (continuous)
+            break;
+
+          logistic_map_.set_seed(123);
+          int32_t logistic_map_r = get_logistic_map_r();
+          if (get_logistic_map_r_cv_source()) {
+            logistic_map_r += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_logistic_map_r_cv_source() - 1)) + 7) >> 4;
+            CONSTRAIN(logistic_map_r, 0, 255);
+          }
+          logistic_map_.set_r(logistic_map_r);
+          if (triggered) {
+            int64_t logistic_map_x = logistic_map_.Clock();
+            uint8_t range = get_logistic_map_range();
+            if (get_logistic_map_range_cv_source()) {
+              range += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_logistic_map_range_cv_source() - 1)) + 15) >> 5;
+              CONSTRAIN(range, 1, 120);
+            }
+
+            if (quantizer_.enabled()) {
+              uint32_t logistic_scaled = (logistic_map_x * range) >> 24;
+
+              // See above, may need tweaking
+              int32_t pitch =
+                  quantizer_.Lookup(64 + range / 2 - logistic_scaled + get_transpose()) + (get_root() << 7);
+              sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, pitch, get_octave(), OC::DAC::get_voltage_scaling(dac_channel));
+              history_sample = pitch + ((OC::DAC::kOctaveZero + get_octave()) * 12 << 7);
+            } else {
+              int octave = get_octave();
+              CONSTRAIN(octave, 0, 6);
+              sample = OC::DAC::get_octave_offset(dac_channel, octave) + (get_transpose() << 7);
+              sample += multiply_u32xu32_rshift24((static_cast<uint32_t>(range) * 65535U) >> 7, logistic_map_x);
+              sample = USAT16(sample);
+              history_sample = sample;
+            }
+          }
+        }
+        break;
+      case CHANNEL_SOURCE_INT_SEQ: {
+            // this doesn't make sense when continuously quantizing; should be hidden via the menu ...
+            if (continuous)
+              break;
+
+            int_seq_.set_loop_direction(get_int_seq_dir());
+            int_seq_.set_brownian_prob(get_int_seq_brownian_prob());
+            int16_t int_seq_index = get_int_seq_index();
+            int16_t int_seq_stride = get_int_seq_stride();
+
+            if (get_int_seq_index_cv_source()) {
+              int_seq_index += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_int_seq_index_cv_source() - 1)) + 127) >> 8;
+            }
+            if (int_seq_index < 0) int_seq_index = 0;
+            if (int_seq_index > 11) int_seq_index = 11;
+            int_seq_.set_int_seq(int_seq_index);
+            int16_t int_seq_modulus_ = get_int_seq_modulus();
+            if (get_int_seq_modulus_cv_source()) {
+                int_seq_modulus_ += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_int_seq_modulus_cv_source() - 1)) + 31) >> 6;
+                CONSTRAIN(int_seq_modulus_, 2, 121);
+            }
+            int_seq_.set_int_seq_modulus(int_seq_modulus_);
+
+            if (get_int_seq_stride_cv_source()) {
+              int_seq_stride += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_int_seq_stride_cv_source() - 1)) + 31) >> 6;
+            }
+            if (int_seq_stride < 1) int_seq_stride = 1;
+            if (int_seq_stride > kIntSeqLen - 1) int_seq_stride = kIntSeqLen - 1;
+            int_seq_.set_fractal_stride(int_seq_stride);
+
+            int_seq_.set_loop_start(get_int_seq_start());
+
+            int_seq_.set_loop_length(get_int_seq_length());
+
+            if (int_seq_reset_) {
+              int_seq_.reset_loop();
+              int_seq_reset_ = false;
+            }
+
+            if (triggered) {
+              // uint32_t is = int_seq_.Clock();
+              // check whether frame should be shifted and if so, by how much.
+              if (get_int_seq_pass_go()) {
+                // OK, we're at the start of a loop or at one end of a pendulum swing
+                uint8_t fs_prob = get_int_seq_frame_shift_prob();
+                uint8_t fs_range = get_int_seq_frame_shift_range();
+                // Serial.print("fs_prob=");
+                // Serial.println(fs_prob);
+                // Serial.print("fs_range=");
+                // Serial.println(fs_range);
+                uint8_t fs_rand = static_cast<uint8_t>(random(0,256)) ;
+                // Serial.print("fs_rand=");
+                // Serial.println(fs_rand);
+                // Serial.println("---");
+                if (fs_rand < fs_prob) {
+                  // OK, move the frame!
+                  int16_t frame_shift = random(-fs_range, fs_range + 1) ;
+                  // Serial.print("frame_shift=");
+                  // Serial.println(frame_shift);
+                  // Serial.print("current start pos=");
+                  // Serial.println(get_int_seq_start());
+                  int16_t new_start_pos = get_int_seq_start() + frame_shift ;
+                  // Serial.print("new_start_pos=");
+                  // Serial.println(new_start_pos);
+                  // Serial.println("===");
+                  if (new_start_pos < 0) new_start_pos = 0;
+                  if (new_start_pos > kIntSeqLen - 2) new_start_pos = kIntSeqLen - 2;
+                  set_int_seq_start(static_cast<uint8_t>(new_start_pos)) ;
+                  int_seq_.set_loop_start(get_int_seq_start());
+                }
+              }
+              uint32_t is = int_seq_.Clock();
+              int16_t range_ = get_int_seq_range();
+              if (get_int_seq_range_cv_source()) {
+                range_ += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_int_seq_range_cv_source() - 1)) + 31) >> 6;
+                CONSTRAIN(range_, 1, 120);
+              }
+              if (quantizer_.enabled()) {
+
+                // Since our range is limited anyway, just grab the last byte
+                uint32_t scaled = ((is >> 4) * range_) >> 8;
+
+                // The quantizer uses a lookup codebook with 128 entries centered
+                // about 0, so we use the range/scaled output to lookup a note
+                // directly instead of changing to pitch first.
+                int32_t pitch =
+                  quantizer_.Lookup(64 + range_ / 2 - scaled + get_transpose()) + (get_root() << 7);
+                sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, pitch, get_octave(), OC::DAC::get_voltage_scaling(dac_channel));
+                history_sample = pitch + ((OC::DAC::kOctaveZero + get_octave()) * 12 << 7);
+              } else {
+                // We dont' need a calibrated value here, really
+                int octave = get_octave();
+                CONSTRAIN(octave, 0, 6);
+                sample = OC::DAC::get_octave_offset(dac_channel, octave) + (get_transpose() << 7);
+                // range is actually 120 (10 oct) but 65535 / 128 is close enough
+                sample += multiply_u32xu32_rshift32((static_cast<uint32_t>(range_) * 65535U) >> 7, is << 20);
+                sample = USAT16(sample);
+                history_sample = sample;
+              }
+            }
+          }
+          break;
+
+      default: {
+          if (update) {
+
+            int32_t transpose = get_transpose() + prev_transpose_cv_;
+            int octave = get_octave() + prev_octave_cv_;
+            int root = get_root() + prev_root_cv_;
+
+            int32_t pitch = quantizer_.enabled()
+                ? OC::ADC::raw_pitch_value(static_cast<ADC_CHANNEL>(source))
+                : OC::ADC::pitch_value(static_cast<ADC_CHANNEL>(source));
+
+            // repurpose channel CV input? --
+            uint8_t _aux_cv_destination = get_aux_cv_dest();
+
+            if (_aux_cv_destination != prev_destination_)
+              clear_dest();
+            prev_destination_ = _aux_cv_destination;
+
+            if (!continuous && index != source) {
+              // this doesn't really work all that well for continuous quantizing...
+              // see below
+
+              switch(_aux_cv_destination) {
+
+                case QQ_DEST_NONE:
+                break;
+                case QQ_DEST_TRANSPOSE:
+                  transpose += (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 63) >> 7;
+                break;
+                case QQ_DEST_ROOT:
+                  root += (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 127) >> 8;
+                break;
+                case QQ_DEST_OCTAVE:
+                  octave += (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 255) >> 9;
+                break;
+                case  QQ_DEST_MASK:
+                  update_scale(false, (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 127) >> 8);
+                break;
+                default:
+                break;
+              }
+            }
+
+            // limit:
+            CONSTRAIN(octave, -4, 4);
+            CONSTRAIN(root, 0, 11);
+            CONSTRAIN(transpose, -12, 12);
+
+            int32_t quantized = quantizer_.Process(pitch, root << 7, transpose);
+            sample = temp_sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, quantized, octave + continuous_offset_, OC::DAC::get_voltage_scaling(dac_channel));
+
+            // continuous mode needs special treatment to give useful results.
+            // basically, update on note change only
+
+            if (continuous && last_sample_ != sample) {
+
+              bool _re_quantize = false;
+              int _aux_cv = 0;
+
+              if (index != source) {
+
+                  switch(_aux_cv_destination) {
+
+                    case QQ_DEST_NONE:
+                    break;
+                    case QQ_DEST_TRANSPOSE:
+                      _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 63) >> 7;
+                      if (_aux_cv != prev_transpose_cv_) {
+                          transpose = get_transpose() + _aux_cv;
+                          CONSTRAIN(transpose, -12, 12);
+                          prev_transpose_cv_ = _aux_cv;
+                          _re_quantize = true;
+                      }
+                    break;
+                    case QQ_DEST_ROOT:
+                      _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 127) >> 8;
+                      if (_aux_cv != prev_root_cv_) {
+                          root = get_root() + _aux_cv;
+                          CONSTRAIN(root, 0, 11);
+                          prev_root_cv_ = _aux_cv;
+                          _re_quantize = true;
+                      }
+                    break;
+                    case QQ_DEST_OCTAVE:
+                      _aux_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 255) >> 9;
+                      if (_aux_cv != prev_octave_cv_) {
+                          octave = get_octave() + _aux_cv;
+                          CONSTRAIN(octave, -4, 4);
+                          prev_octave_cv_ = _aux_cv;
+                          _re_quantize = true;
+                      }
+                    break;
+                    case QQ_DEST_MASK:
+                      schedule_mask_rotate_ = (OC::ADC::value(static_cast<ADC_CHANNEL>(index)) + 127) >> 8;
+                      update_scale(force_update_, schedule_mask_rotate_);
+                    break;
+                    default:
+                    break;
+                  }
+                  // end switch
+              }
+
+              // offset when TR source = continuous ?
+              int8_t _trigger_offset = 0;
+              bool _trigger_update = false;
+              if (OC::DigitalInputs::read_immediate(static_cast<OC::DigitalInput>(index))) {
+                 _trigger_offset = (trigger_source == CHANNEL_TRIGGER_CONTINUOUS_UP) ? 1 : -1;
+              }
+              if (_trigger_offset != continuous_offset_)
+                 _trigger_update = true;
+              continuous_offset_ = _trigger_offset;
+
+              // run quantizer again -- presumably could be made more efficient...
+              if (_re_quantize)
+                quantized = quantizer_.Process(pitch, root << 7, transpose);
+              if (_re_quantize || _trigger_update)
+                sample = OC::DAC::pitch_to_scaled_voltage_dac(dac_channel, quantized, octave + continuous_offset_, OC::DAC::get_voltage_scaling(dac_channel));
+            }
+            // end special treatment
+
+            history_sample = quantized + ((OC::DAC::kOctaveZero + octave + continuous_offset_) * 12 << 7);
+          }
+        }
+    } // end switch
+
+    bool changed = continuous ? (last_sample_ != temp_sample) : (last_sample_ != sample);
+
+    if (changed) {
+      MENU_REDRAW = 1;
+      last_sample_ = continuous ? temp_sample : sample;
+    }
+
+    OC::DAC::set(dac_channel, sample + get_fine());
+
+    if (triggered || (continuous && changed)) {
+      scrolling_history_.Push(history_sample);
+      trigger_display_.Update(1, true);
+    } else {
+      trigger_display_.Update(1, false);
+    }
+    scrolling_history_.Update();
+  }
+
+  // Wrappers for ScaleEdit
+  void scale_changed() {
+    force_update_ = true;
+  }
+
+  uint16_t get_scale_mask(uint8_t scale_select) const {
+    return get_mask();
+  }
+
+  void update_scale_mask(uint16_t mask, uint16_t dummy) {
+    apply_value(CHANNEL_SETTING_MASK, mask); // Should automatically be updated
+    last_mask_ = mask;
+    force_update_ = true;
+  }
+  //
+
+  uint8_t getTriggerState() const {
+    return trigger_display_.getState();
+  }
+
+  uint32_t get_shift_register() const {
+    return turing_machine_.get_shift_register();
+  }
+
+  uint32_t get_logistic_map_register() const {
+    return logistic_map_.get_register();
+  }
+
+  uint32_t get_bytebeat_register() const {
+    return bytebeat_.get_last_sample();
+  }
+
+  uint32_t get_int_seq_register() const {
+    return int_seq_.get_register();
+  }
+
+  int16_t get_int_seq_k() const {
+    return int_seq_.get_k();
+  }
+
+  int16_t get_int_seq_l() const {
+    return int_seq_.get_l();
+  }
+
+  int16_t get_int_seq_i() const {
+    return int_seq_.get_i();
+  }
+
+  int16_t get_int_seq_j() const {
+    return int_seq_.get_j();
+  }
+
+  int16_t get_int_seq_n() const {
+    return int_seq_.get_n();
+  }
+
+  int16_t get_int_seq_x() const {
+    return int_seq_.get_x();
+  }
+
+  bool get_int_seq_pass_go() const {
+   return int_seq_.get_pass_go();
+  }
+
+  // Maintain an internal list of currently available settings, since some are
+  // dependent on others. It's kind of brute force, but eh, works :) If other
+  // apps have a similar need, it can be moved to a common wrapper
+
+  int num_enabled_settings() const {
+    return num_enabled_settings_;
+  }
+
+  ChannelSetting enabled_setting_at(int index) const {
+    return enabled_settings_[index];
+  }
+
+  void update_enabled_settings() {
+    ChannelSetting *settings = enabled_settings_;
+    *settings++ = CHANNEL_SETTING_SCALE;
+    if (OC::Scales::SCALE_NONE != get_scale(DUMMY)) {
+      *settings++ = CHANNEL_SETTING_ROOT;
+      *settings++ = CHANNEL_SETTING_MASK;
+    }
+    *settings++ = CHANNEL_SETTING_SOURCE;
+    switch (get_source()) {
+      case CHANNEL_SOURCE_CV1:
+      case CHANNEL_SOURCE_CV2:
+      case CHANNEL_SOURCE_CV3:
+      case CHANNEL_SOURCE_CV4:
+        if (get_source() != get_channel_index())
+         *settings++ = CHANNEL_SETTING_AUX_SOURCE_DEST;
+      break;
+      case CHANNEL_SOURCE_TURING:
+        *settings++ = CHANNEL_SETTING_TURING_LENGTH;
+        if (OC::Scales::SCALE_NONE != get_scale(DUMMY))
+            *settings++ = CHANNEL_SETTING_TURING_MODULUS;
+        *settings++ = CHANNEL_SETTING_TURING_RANGE;
+        *settings++ = CHANNEL_SETTING_TURING_PROB;
+        if (OC::Scales::SCALE_NONE != get_scale(DUMMY))
+            *settings++ = CHANNEL_SETTING_TURING_MODULUS_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_TURING_RANGE_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_TURING_PROB_CV_SOURCE;
+      break;
+      case CHANNEL_SOURCE_LOGISTIC_MAP:
+        *settings++ = CHANNEL_SETTING_LOGISTIC_MAP_R;
+        *settings++ = CHANNEL_SETTING_LOGISTIC_MAP_RANGE;
+        *settings++ = CHANNEL_SETTING_LOGISTIC_MAP_R_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_LOGISTIC_MAP_RANGE_CV_SOURCE;
+      break;
+      case CHANNEL_SOURCE_BYTEBEAT:
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_EQUATION;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_RANGE;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_P0;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_P1;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_P2;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_EQUATION_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_RANGE_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_P0_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_P1_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_BYTEBEAT_P2_CV_SOURCE;
+      break;
+      case CHANNEL_SOURCE_INT_SEQ:
+        *settings++ = CHANNEL_SETTING_INT_SEQ_INDEX;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_MODULUS;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_RANGE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_DIRECTION;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_BROWNIAN_PROB;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_LOOP_START;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_LOOP_LENGTH;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_STRIDE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_STRIDE_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_PROB;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_RANGE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_INDEX_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_MODULUS_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_RANGE_CV_SOURCE;
+        *settings++ = CHANNEL_SETTING_INT_SEQ_RESET_TRIGGER;
+      break;
+      default:
+      break;
+    }
+    *settings++ = CHANNEL_SETTING_TRIGGER;
+    if (get_trigger_source() < CHANNEL_TRIGGER_CONTINUOUS_UP) {
+      *settings++ = CHANNEL_SETTING_CLKDIV;
+      *settings++ = CHANNEL_SETTING_DELAY;
+    }
+    *settings++ = CHANNEL_SETTING_OCTAVE;
+    *settings++ = CHANNEL_SETTING_TRANSPOSE;
+    *settings++ = CHANNEL_SETTING_FINE;
+
+    num_enabled_settings_ = settings - enabled_settings_;
+  }
+
+  static bool indentSetting(ChannelSetting s) {
+    switch (s) {
+      case CHANNEL_SETTING_TURING_LENGTH:
+      case CHANNEL_SETTING_TURING_MODULUS:
+      case CHANNEL_SETTING_TURING_RANGE:
+      case CHANNEL_SETTING_TURING_PROB:
+      case CHANNEL_SETTING_TURING_MODULUS_CV_SOURCE:
+      case CHANNEL_SETTING_TURING_RANGE_CV_SOURCE:
+      case CHANNEL_SETTING_TURING_PROB_CV_SOURCE:
+      case CHANNEL_SETTING_LOGISTIC_MAP_R:
+      case CHANNEL_SETTING_LOGISTIC_MAP_RANGE:
+      case CHANNEL_SETTING_LOGISTIC_MAP_R_CV_SOURCE:
+      case CHANNEL_SETTING_LOGISTIC_MAP_RANGE_CV_SOURCE:
+      case CHANNEL_SETTING_BYTEBEAT_EQUATION:
+      case CHANNEL_SETTING_BYTEBEAT_RANGE:
+      case CHANNEL_SETTING_BYTEBEAT_P0:
+      case CHANNEL_SETTING_BYTEBEAT_P1:
+      case CHANNEL_SETTING_BYTEBEAT_P2:
+      case CHANNEL_SETTING_BYTEBEAT_EQUATION_CV_SOURCE:
+      case CHANNEL_SETTING_BYTEBEAT_RANGE_CV_SOURCE:
+      case CHANNEL_SETTING_BYTEBEAT_P0_CV_SOURCE:
+      case CHANNEL_SETTING_BYTEBEAT_P1_CV_SOURCE:
+      case CHANNEL_SETTING_BYTEBEAT_P2_CV_SOURCE:
+      case CHANNEL_SETTING_INT_SEQ_INDEX:
+      case CHANNEL_SETTING_INT_SEQ_MODULUS:
+      case CHANNEL_SETTING_INT_SEQ_RANGE:
+      case CHANNEL_SETTING_INT_SEQ_DIRECTION:
+      case CHANNEL_SETTING_INT_SEQ_BROWNIAN_PROB:
+      case CHANNEL_SETTING_INT_SEQ_LOOP_START:
+      case CHANNEL_SETTING_INT_SEQ_LOOP_LENGTH:
+      case CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_PROB:
+      case CHANNEL_SETTING_INT_SEQ_FRAME_SHIFT_RANGE:
+      case CHANNEL_SETTING_INT_SEQ_STRIDE:
+      case CHANNEL_SETTING_INT_SEQ_INDEX_CV_SOURCE:
+      case CHANNEL_SETTING_INT_SEQ_MODULUS_CV_SOURCE:
+      case CHANNEL_SETTING_INT_SEQ_RANGE_CV_SOURCE:
+      case CHANNEL_SETTING_INT_SEQ_STRIDE_CV_SOURCE:
+      case CHANNEL_SETTING_INT_SEQ_RESET_TRIGGER:
+      case CHANNEL_SETTING_CLKDIV:
+      case CHANNEL_SETTING_DELAY:
+        return true;
+      default: break;
+    }
+    return false;
+  }
+
+  void RenderScreensaver(weegfx::coord_t x) const;
+
+private:
+  bool force_update_;
+  bool instant_update_;
+  int last_scale_;
+  uint16_t last_mask_;
+  int32_t last_sample_;
+  uint8_t clock_;
+  bool int_seq_reset_;
+  int8_t continuous_offset_;
+  int8_t channel_index_;
+  int32_t schedule_mask_rotate_;
+  int8_t prev_destination_;
+  int8_t prev_octave_cv_;
+  int8_t prev_transpose_cv_;
+  int8_t prev_root_cv_;
+
+  util::TriggerDelay<OC::kMaxTriggerDelayTicks> trigger_delay_;
+  util::TuringShiftRegister turing_machine_;
+  util::LogisticMap logistic_map_;
+  peaks::ByteBeat bytebeat_ ;
+  util::IntegerSequence int_seq_ ;
+  braids::Quantizer quantizer_;
+  OC::DigitalInputDisplay trigger_display_;
+
+  int num_enabled_settings_;
+  ChannelSetting enabled_settings_[CHANNEL_SETTING_LAST];
+
+  OC::vfx::ScrollingHistory<int32_t, 5> scrolling_history_;
+
+  bool update_scale(bool force, int32_t mask_rotate) {
+
+    force_update_ = false;
+    const int scale = get_scale(DUMMY);
+    uint16_t mask = get_mask();
+
+    if (mask_rotate)
+      mask = OC::ScaleEditor<QuantizerChannel>::RotateMask(mask, OC::Scales::GetScale(scale).num_notes, mask_rotate);
+
+    if (force || (last_scale_ != scale || last_mask_ != mask)) {
+      last_scale_ = scale;
+      last_mask_ = mask;
+      quantizer_.Configure(OC::Scales::GetScale(scale), mask);
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+const char* const channel_input_sources[CHANNEL_SOURCE_LAST] = {
+  "CV1", "CV2", "CV3", "CV4", "Turing", "Lgstc", "ByteB", "IntSq"
+};
+
+const char* const aux_cv_dest[5] = {
+  "-", "root", "oct", "trns", "mask"
+};
+
+SETTINGS_DECLARE(QuantizerChannel, CHANNEL_SETTING_LAST) {
+  { OC::Scales::SCALE_SEMI, 0, OC::Scales::NUM_SCALES - 1, "Scale", OC::scale_names, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 11, "Root", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 65535, 1, 65535, "Active notes", NULL, settings::STORAGE_TYPE_U16 },
+  { CHANNEL_SOURCE_CV1, CHANNEL_SOURCE_CV1, CHANNEL_SOURCE_LAST - 1, "CV Source", channel_input_sources, settings::STORAGE_TYPE_U8 },
+  { QQ_DEST_NONE, QQ_DEST_NONE, QQ_DEST_LAST - 1, "CV aux >", aux_cv_dest, settings::STORAGE_TYPE_U8 },
+  { CHANNEL_TRIGGER_CONTINUOUS_DOWN, 0, CHANNEL_TRIGGER_LAST - 1, "Trigger source", OC::Strings::channel_trigger_sources, settings::STORAGE_TYPE_U8 },
+  { 1, 1, 16, "Clock div", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, OC::kNumDelayTimes - 1, "Trigger delay", OC::Strings::trigger_delay_times, settings::STORAGE_TYPE_U8 },
+  { 0, -5, 7, "Transpose", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -4, 4, "Octave", NULL, settings::STORAGE_TYPE_I8 },
+  { 0, -999, 999, "Fine", NULL, settings::STORAGE_TYPE_I16 },
+  { 16, 1, 32, "LFSR length", NULL, settings::STORAGE_TYPE_U8 },
+  { 128, 0, 255, "LFSR prb", NULL, settings::STORAGE_TYPE_U8 },
+  { 24, 2, 121, "LFSR modulus", NULL, settings::STORAGE_TYPE_U8 },
+  { 12, 1, 120, "LFSR range", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 4, "LFSR prb CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "LFSR mod CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "LFSR rng CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 128, 1, 255, "Logistic r", NULL, settings::STORAGE_TYPE_U8 },
+  { 12, 1, 120, "Logistic range", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 4, "Log r   CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "Log rng CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 15, "Bytebeat eqn", OC::Strings::bytebeat_equation_names, settings::STORAGE_TYPE_U8 },
+  { 12, 1, 120, "Bytebeat rng", NULL, settings::STORAGE_TYPE_U8 },
+  { 8, 1, 255, "Bytebeat P0", NULL, settings::STORAGE_TYPE_U8 },
+  { 12, 1, 255, "Bytebeat P1", NULL, settings::STORAGE_TYPE_U8 },
+  { 14, 1, 255, "Bytebeat P2", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 4, "Bb eqn CV src", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "Bb rng CV src", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "Bb P0  CV src", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "Bb P1  CV src", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "Bb P2  CV src", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 11, "IntSeq", OC::Strings::integer_sequence_names, settings::STORAGE_TYPE_U4 },
+  { 24, 2, 121, "IntSeq modul.", NULL, settings::STORAGE_TYPE_U8 },
+  { 12, 1, 120, "IntSeq range", NULL, settings::STORAGE_TYPE_U8 },
+  { 1, 0, 1, "IntSeq dir", OC::Strings::integer_sequence_dirs, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 255, "> Brownian prob", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, kIntSeqLen - 2, "IntSeq start", NULL, settings::STORAGE_TYPE_U8 },
+  { 8, 2, kIntSeqLen, "IntSeq len", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 255, "IntSeq FS prob", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 5, "IntSeq FS rng", NULL, settings::STORAGE_TYPE_U4 },
+  { 1, 1, kIntSeqLen - 1, "Fractal stride", NULL, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 4, "IntSeq CV   >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "IntSeq mod CV", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "IntSeq rng CV", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "F. stride CV >", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "IntSeq reset", OC::Strings::trigger_input_names_none, settings::STORAGE_TYPE_U4 }
+};
+
+// WIP refactoring to better encapsulate and for possible app interface change
+class QuadQuantizer {
+public:
+  void Init() {
+    selected_channel = 0;
+    cursor.Init(CHANNEL_SETTING_SCALE, CHANNEL_SETTING_LAST - 1);
+    scale_editor.Init(false);
+  }
+
+  inline bool editing() const {
+    return cursor.editing();
+  }
+
+  inline int cursor_pos() const {
+    return cursor.cursor_pos();
+  }
+
+  int selected_channel;
+  OC::menu::ScreenCursor<OC::menu::kScreenLines> cursor;
+  OC::ScaleEditor<QuantizerChannel> scale_editor;
+};
+
+QuadQuantizer qq_state;
+QuantizerChannel quantizer_channels[4];
+
+void QQ_init() {
+
+  qq_state.Init();
+  for (size_t i = 0; i < 4; ++i) {
+    quantizer_channels[i].Init(static_cast<ChannelSource>(CHANNEL_SOURCE_CV1 + i),
+                               static_cast<ChannelTriggerSource>(CHANNEL_TRIGGER_TR1 + i));
+  }
+
+  qq_state.cursor.AdjustEnd(quantizer_channels[0].num_enabled_settings() - 1);
+}
+
+size_t QQ_storageSize() {
+  return 4 * QuantizerChannel::storageSize();
+}
+
+size_t QQ_save(void *storage) {
+  size_t used = 0;
+  for (size_t i = 0; i < 4; ++i) {
+    used += quantizer_channels[i].Save(static_cast<char*>(storage) + used);
+  }
+  return used;
+}
+
+size_t QQ_restore(const void *storage) {
+  size_t used = 0;
+  for (size_t i = 0; i < 4; ++i) {
+    used += quantizer_channels[i].Restore(static_cast<const char*>(storage) + used);
+    quantizer_channels[i].update_scale_mask(quantizer_channels[i].get_mask(), 0x0);
+    quantizer_channels[i].update_enabled_settings();
+  }
+  qq_state.cursor.AdjustEnd(quantizer_channels[0].num_enabled_settings() - 1);
+  return used;
+}
+
+void QQ_handleAppEvent(OC::AppEvent event) {
+  switch (event) {
+    case OC::APP_EVENT_RESUME:
+      qq_state.cursor.set_editing(false);
+      qq_state.scale_editor.Close();
+      break;
+    case OC::APP_EVENT_SUSPEND:
+    case OC::APP_EVENT_SCREENSAVER_ON:
+    case OC::APP_EVENT_SCREENSAVER_OFF:
+      break;
+  }
+}
+
+void QQ_isr() {
+  uint32_t triggers = OC::DigitalInputs::clocked();
+  quantizer_channels[0].Update(triggers, DAC_CHANNEL_A);
+  quantizer_channels[1].Update(triggers, DAC_CHANNEL_B);
+  quantizer_channels[2].Update(triggers, DAC_CHANNEL_C);
+  quantizer_channels[3].Update(triggers, DAC_CHANNEL_D);
+}
+
+void QQ_loop() {
+}
+
+void QQ_menu() {
+
+  OC::menu::QuadTitleBar::Draw();
+  for (int i = 0, x = 0; i < 4; ++i, x += 32) {
+    const QuantizerChannel &channel = quantizer_channels[i];
+    OC::menu::QuadTitleBar::SetColumn(i);
+    graphics.print((char)('A' + i));
+    graphics.movePrintPos(2, 0);
+    int octave = channel.get_octave();
+    if (octave)
+      graphics.pretty_print(octave);
+
+    OC::menu::QuadTitleBar::DrawGateIndicator(i, channel.getTriggerState());
+  }
+  OC::menu::QuadTitleBar::Selected(qq_state.selected_channel);
+
+
+  const QuantizerChannel &channel = quantizer_channels[qq_state.selected_channel];
+
+  OC::menu::SettingsList<OC::menu::kScreenLines, 0, OC::menu::kDefaultValueX> settings_list(qq_state.cursor);
+  OC::menu::SettingsListItem list_item;
+  while (settings_list.available()) {
+    const int setting =
+        channel.enabled_setting_at(settings_list.Next(list_item));
+    const int value = channel.get_value(setting);
+    const settings::value_attr &attr = QuantizerChannel::value_attr(setting);
+
+    switch (setting) {
+      case CHANNEL_SETTING_SCALE:
+        list_item.SetPrintPos();
+        if (list_item.editing) {
+          OC::menu::DrawEditIcon(6, list_item.y, value, attr);
+          graphics.movePrintPos(6, 0);
+        }
+        graphics.print(OC::scale_names[value]);
+        list_item.DrawCustom();
+        break;
+      case CHANNEL_SETTING_MASK:
+        OC::menu::DrawMask<false, 16, 8, 1>(OC::menu::kDisplayWidth, list_item.y, channel.get_rotated_scale_mask(), OC::Scales::GetScale(channel.get_scale(DUMMY)).num_notes);
+        list_item.DrawNoValue<false>(value, attr);
+        break;
+      case CHANNEL_SETTING_TRIGGER:
+      {
+        if (channel.get_source() > CHANNEL_SOURCE_CV4)
+           list_item.DrawValueMax(value, attr, CHANNEL_TRIGGER_TR4);
+        else
+          list_item.DrawDefault(value, attr);
+      }
+        break;
+      case CHANNEL_SETTING_SOURCE:
+        if (CHANNEL_SOURCE_TURING == channel.get_source()) {
+          int turing_length = channel.get_turing_length();
+          int w = turing_length >= 16 ? 16 * 3 : turing_length * 3;
+
+          OC::menu::DrawMask<true, 16, 8, 1>(OC::menu::kDisplayWidth, list_item.y, channel.get_shift_register(), turing_length);
+          list_item.valuex = OC::menu::kDisplayWidth - w - 1;
+          list_item.DrawNoValue<true>(value, attr);
+          break;
+          // Fall through if not Turing
+        }
+      default:
+        if (QuantizerChannel::indentSetting(static_cast<ChannelSetting>(setting)))
+          list_item.x += OC::menu::kIndentDx;
+        if (setting == CHANNEL_SETTING_SOURCE && channel.get_trigger_source() > CHANNEL_TRIGGER_TR4)
+          list_item.DrawValueMax(value, attr, CHANNEL_TRIGGER_TR4);
+        else list_item.DrawDefault(value, attr);
+      break;
+    }
+  }
+
+  if (qq_state.scale_editor.active())
+    qq_state.scale_editor.Draw();
+}
+
+void QQ_handleButtonEvent(const UI::Event &event) {
+
+  if (UI::EVENT_BUTTON_LONG_PRESS == event.type && OC::CONTROL_BUTTON_DOWN == event.control)
+    QQ_downButtonLong();
+
+  if (qq_state.scale_editor.active()) {
+    qq_state.scale_editor.HandleButtonEvent(event);
+    return;
+  }
+
+  if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        QQ_topButton();
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        QQ_lowerButton();
+        break;
+      case OC::CONTROL_BUTTON_L:
+        QQ_leftButton();
+        break;
+      case OC::CONTROL_BUTTON_R:
+        QQ_rightButton();
+        break;
+    }
+  } else {
+    if (OC::CONTROL_BUTTON_L == event.control)
+      QQ_leftButtonLong();
+  }
+}
+
+void QQ_handleEncoderEvent(const UI::Event &event) {
+  if (qq_state.scale_editor.active()) {
+    qq_state.scale_editor.HandleEncoderEvent(event);
+    return;
+  }
+
+  if (OC::CONTROL_ENCODER_L == event.control) {
+    int selected_channel = qq_state.selected_channel + event.value;
+    CONSTRAIN(selected_channel, 0, 3);
+    qq_state.selected_channel = selected_channel;
+
+    QuantizerChannel &selected = quantizer_channels[qq_state.selected_channel];
+    qq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+  } else if (OC::CONTROL_ENCODER_R == event.control) {
+    QuantizerChannel &selected = quantizer_channels[qq_state.selected_channel];
+    if (qq_state.editing()) {
+      ChannelSetting setting = selected.enabled_setting_at(qq_state.cursor_pos());
+      if (CHANNEL_SETTING_MASK != setting) {
+
+        int event_value = event.value;
+
+        switch (setting) {
+          case CHANNEL_SETTING_TRIGGER:
+          {
+            if (selected.get_trigger_source() == CHANNEL_TRIGGER_TR4 && selected.get_source() > CHANNEL_SOURCE_CV4 && event.value > 0)
+              event_value = 0x0;
+          }
+          break;
+          case CHANNEL_SETTING_SOURCE: {
+             if (selected.get_source() == CHANNEL_SOURCE_CV4 && selected.get_trigger_source() > CHANNEL_TRIGGER_TR4 && event.value > 0)
+              event_value = 0x0;
+          }
+          break;
+          default:
+          break;
+        }
+
+        if (selected.change_value(setting, event_value))
+          selected.force_update();
+
+        switch (setting) {
+          case CHANNEL_SETTING_SCALE:
+          case CHANNEL_SETTING_TRIGGER:
+          case CHANNEL_SETTING_SOURCE:
+            selected.update_enabled_settings();
+            qq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+          break;
+          default:
+          break;
+        }
+      }
+    } else {
+      qq_state.cursor.Scroll(event.value);
+    }
+  }
+}
+
+void QQ_topButton() {
+  QuantizerChannel &selected = quantizer_channels[qq_state.selected_channel];
+  if (selected.change_value(CHANNEL_SETTING_OCTAVE, 1)) {
+    selected.force_update();
+  }
+}
+
+void QQ_lowerButton() {
+  QuantizerChannel &selected = quantizer_channels[qq_state.selected_channel];
+  if (selected.change_value(CHANNEL_SETTING_OCTAVE, -1)) {
+    selected.force_update();
+  }
+}
+
+void QQ_rightButton() {
+  QuantizerChannel &selected = quantizer_channels[qq_state.selected_channel];
+  switch (selected.enabled_setting_at(qq_state.cursor_pos())) {
+    case CHANNEL_SETTING_MASK: {
+      int scale = selected.get_scale(DUMMY);
+      if (OC::Scales::SCALE_NONE != scale) {
+        qq_state.scale_editor.Edit(&selected, scale);
+      }
+    }
+    break;
+    default:
+      qq_state.cursor.toggle_editing();
+      break;
+  }
+}
+
+void QQ_leftButton() {
+  qq_state.selected_channel = (qq_state.selected_channel + 1) & 3;
+  QuantizerChannel &selected = quantizer_channels[qq_state.selected_channel];
+  qq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+}
+
+void QQ_leftButtonLong() {
+  QuantizerChannel &selected_channel = quantizer_channels[qq_state.selected_channel];
+  int scale = selected_channel.get_scale(DUMMY);
+  int root = selected_channel.get_root();
+  for (int i = 0; i < 4; ++i) {
+    if (i != qq_state.selected_channel) {
+      quantizer_channels[i].apply_value(CHANNEL_SETTING_ROOT, root);
+      quantizer_channels[i].set_scale(scale);
+    }
+  }
+}
+
+void QQ_downButtonLong() {
+
+  QuantizerChannel &selected_channel = quantizer_channels[qq_state.selected_channel];
+  selected_channel.update_scale_mask(0xFFFF, 0x0);
+}
+
+int32_t history[5];
+static const weegfx::coord_t kBottom = 60;
+
+inline int32_t render_pitch(int32_t pitch, weegfx::coord_t x, weegfx::coord_t width) {
+  CONSTRAIN(pitch, 0, 120 << 7);
+  int32_t octave = pitch / (12 << 7);
+  pitch -= (octave * 12 << 7);
+  graphics.drawHLine(x, kBottom - ((pitch * 4) >> 7), width);
+  return octave;
+}
+
+void QuantizerChannel::RenderScreensaver(weegfx::coord_t start_x) const {
+
+  // History
+  scrolling_history_.Read(history);
+  weegfx::coord_t scroll_pos = (scrolling_history_.get_scroll_pos() * 6) >> 8;
+
+  // Top: Show gate & CV (or register bits)
+  OC::menu::DrawGateIndicator(start_x + 1, 2, getTriggerState());
+  const ChannelSource source = get_source();
+  switch (source) {
+    case CHANNEL_SOURCE_TURING:
+      OC::menu::DrawMask<true, 8, 8, 1>(start_x + 31, 1, get_shift_register(), get_turing_length());
+      break;
+    case CHANNEL_SOURCE_LOGISTIC_MAP:
+      OC::menu::DrawMask<true, 8, 8, 1>(start_x + 31, 1, get_logistic_map_register(), 32);
+      break;
+    case CHANNEL_SOURCE_BYTEBEAT:
+      OC::menu::DrawMask<true, 8, 8, 1>(start_x + 31, 1, get_bytebeat_register(), 8);
+      break;
+    case CHANNEL_SOURCE_INT_SEQ:
+      // graphics.setPrintPos(start_x + 31 - 16, 4);
+      graphics.setPrintPos(start_x + 8, 4);
+      graphics.print(get_int_seq_k());
+      // menu::DrawMask<true, 8, 8, 1>(start_x + 31, 1, get_int_seq_register(), 8);
+      break;
+    default: {
+      graphics.setPixel(start_x + QQ_OFFSET_X - 16, 4);
+      int32_t cv = OC::ADC::value(static_cast<ADC_CHANNEL>(source));
+      cv = (cv * 24 + 2047) >> 12;
+      if (cv < 0)
+        graphics.drawRect(start_x + QQ_OFFSET_X - 16 + cv, 6, -cv, 2);
+      else if (cv > 0)
+        graphics.drawRect(start_x + QQ_OFFSET_X - 16, 6, cv, 2);
+      else
+        graphics.drawRect(start_x + QQ_OFFSET_X - 16, 6, 1, 2);
+    }
+    break;
+  }
+
+#ifdef QQ_DEBUG_SCREENSAVER
+  graphics.drawVLinePattern(start_x + 31, 0, 64, 0x55);
+#endif
+
+  // Draw semitone intervals, 4px apart
+  weegfx::coord_t x = start_x + 26;
+  weegfx::coord_t y = kBottom;
+  for (int i = 0; i < 12; ++i, y -= 4)
+    graphics.setPixel(x, y);
+
+  x = start_x + 1;
+  render_pitch(history[0], x, scroll_pos); x += scroll_pos;
+  render_pitch(history[1], x, 6); x += 6;
+  render_pitch(history[2], x, 6); x += 6;
+  render_pitch(history[3], x, 6); x += 6;
+
+  int32_t octave = render_pitch(history[4], x, 6 - scroll_pos);
+  graphics.drawBitmap8(start_x + 28, kBottom - octave * 4 - 1, OC::kBitmapLoopMarkerW, OC::bitmap_loop_markers_8 + OC::kBitmapLoopMarkerW);
+}
+
+void QQ_screensaver() {
+#ifdef QQ_DEBUG_SCREENSAVER
+  debug::CycleMeasurement render_cycles;
+#endif
+
+  quantizer_channels[0].RenderScreensaver(0);
+  quantizer_channels[1].RenderScreensaver(32);
+  quantizer_channels[2].RenderScreensaver(64);
+  quantizer_channels[3].RenderScreensaver(96);
+
+#ifdef QQ_DEBUG_SCREENSAVER
+  graphics.drawHLine(0, menu::kMenuLineH, menu::kDisplayWidth);
+  uint32_t us = debug::cycles_to_us(render_cycles.read());
+  graphics.setPrintPos(0, 32);
+  graphics.printf("%u",  us);
+#endif
+}
+
+#ifdef QQ_DEBUG
+void QQ_debug() {
+  for (int i = 0; i < 4; ++i) {
+    uint8_t ypos = 10*(i + 1) + 2 ;
+    graphics.setPrintPos(2, ypos);
+    graphics.print(quantizer_channels[i].get_int_seq_i());
+    graphics.setPrintPos(30, ypos);
+    graphics.print(quantizer_channels[i].get_int_seq_l());
+    graphics.setPrintPos(58, ypos);
+    graphics.print(quantizer_channels[i].get_int_seq_j());
+    graphics.setPrintPos(80, ypos);
+    graphics.print(quantizer_channels[i].get_int_seq_k());
+    graphics.setPrintPos(104, ypos);
+    graphics.print(quantizer_channels[i].get_int_seq_x());
+ }
+}
+#endif // QQ_DEBUG

--- a/software/o_c_REV/APP_SEQ.ino
+++ b/software/o_c_REV/APP_SEQ.ino
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#ifdef ENABLE_APP_SEQUINS
 
 #include "util/util_settings.h"
 #include "util/util_trigger_delay.h"
@@ -2630,3 +2631,5 @@ void SEQ_screensaver() {
   seq_channel[1].RenderScreensaver();
 }
 
+
+#endif // ENABLE_APP_SEQUINS

--- a/software/o_c_REV/APP_SEQ.ino
+++ b/software/o_c_REV/APP_SEQ.ino
@@ -1,0 +1,2632 @@
+// Copyright (c) 2015, 2016 Max Stadler, Patrick Dowling
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+#include "util/util_settings.h"
+#include "util/util_trigger_delay.h"
+#include "OC_apps.h"
+#include "OC_DAC.h"
+#include "OC_menus.h"
+#include "OC_ui.h"
+#include "OC_strings.h"
+#include "OC_visualfx.h"
+#include "OC_sequence_edit.h"
+#include "OC_patterns.h"
+#include "OC_scales.h"
+#include "OC_scale_edit.h"
+#include "OC_input_map.h"
+#include "OC_input_maps.h"
+#include "braids_quantizer.h"
+#include "braids_quantizer_scales.h"
+#include "extern/dspinst.h"
+#include "util/util_arp.h"
+#include "peaks_multistage_envelope.h"
+
+
+namespace menu = OC::menu;
+
+const uint8_t NUM_CHANNELS = 2;
+const uint8_t MULT_MAX = 26;    // max multiplier
+const uint8_t MULT_BY_ONE = 19; // default multiplication
+const uint8_t PULSEW_MAX = 255; // max pulse width [ms]
+
+const uint32_t SCALE_PULSEWIDTH = 58982; // 0.9 for signed_multiply_32x16b
+const uint32_t TICKS_TO_MS = 43691; // 0.6667f : fraction, if TU_CORE_TIMER_RATE = 60 us : 65536U * ((1000 / TU_CORE_TIMER_RATE) - 16)
+const uint32_t TICK_JITTER = 0xFFFFFFF;  // 1/16 : threshold/double triggers reject -> ext_frequency_in_ticks_
+const uint32_t TICK_SCALE  = 0xC0000000; // 0.75 for signed_multiply_32x32
+const uint32_t COPYTIMEOUT = 200000; // in ticks
+
+void SEQ_leftButton();
+void SEQ_leftButtonLong();
+void SEQ_upButtonLong();
+void SEQ_downButtonLong();
+void SEQ_upButton();
+void SEQ_downButton();
+void SEQ_rightButton();
+
+uint32_t ticks_src1 = 0; // main clock frequency (top)
+uint32_t ticks_src2 = 0; // sec. clock frequency (bottom)
+
+// copy sequence, global
+uint8_t copy_sequence = 0;
+uint8_t copy_length = OC::Patterns::kMax;
+uint16_t copy_mask = 0xFFFF;
+uint64_t copy_timeout = COPYTIMEOUT;
+
+const uint64_t multipliers_[] = {
+
+  0xFFFFFFFF, // x1
+  0x80000000, // x2
+  0x55555555, // x3
+  0x40000000, // x4
+  0x33333333, // x5
+  0x2AAAAAAB, // x6
+  0x24924925, // x7
+  0x20000000  // x8
+
+}; // = 2^32 / multiplier
+
+const uint64_t pw_scale_[] = {
+
+  0xFFFFFFFF, // /64
+  0xFBFFFFFF, // /63
+  0xF7FFFFFF, // /62
+  0xC3FFFFFF, // /49
+  0xC0000000, // /48
+  0xBBFFFFFF, // /47
+  0x83FFFFFF, // /33
+  0x80000000, // /32
+  0x7BFFFFFF, // /31
+  0x43FFFFFF, // /17
+  0x40000000, // /16
+  0x3BFFFFFF, // /15
+  0x20000000, // /8
+  0x1C000000, // /7
+  0x18000000, // /6
+  0x14000000, // /5
+  0x10000000, // /4
+  0xC000000,  // /3
+  0x8000000,  // /2
+  0x4000000,  // x1
+
+}; // = 0xFFFFFFFF * divisor / 64
+
+const uint8_t divisors_[] = {
+   64,
+   63,
+   62,
+   49,
+   48,
+   47,
+   33,
+   32,
+   31,
+   17,
+   16,
+   15,
+   8,
+   7,
+   6,
+   5,
+   4,
+   3,
+   2,
+   1
+};
+
+enum SEQ_ChannelSetting {
+
+  SEQ_CHANNEL_SETTING_MODE, //
+  SEQ_CHANNEL_SETTING_CLOCK,
+  SEQ_CHANNEL_SETTING_TRIGGER_DELAY,
+  SEQ_CHANNEL_SETTING_RESET,
+  SEQ_CHANNEL_SETTING_MULT,
+  SEQ_CHANNEL_SETTING_PULSEWIDTH,
+  //
+  SEQ_CHANNEL_SETTING_SCALE,
+  SEQ_CHANNEL_SETTING_OCTAVE,
+  SEQ_CHANNEL_SETTING_ROOT,
+  SEQ_CHANNEL_SETTING_OCTAVE_AUX,
+  SEQ_CHANNEL_SETTING_SCALE_MASK,
+  //
+  SEQ_CHANNEL_SETTING_MASK1,
+  SEQ_CHANNEL_SETTING_MASK2,
+  SEQ_CHANNEL_SETTING_MASK3,
+  SEQ_CHANNEL_SETTING_MASK4,
+  SEQ_CHANNEL_SETTING_SEQUENCE,
+  SEQ_CHANNEL_SETTING_SEQUENCE_LEN1,
+  SEQ_CHANNEL_SETTING_SEQUENCE_LEN2,
+  SEQ_CHANNEL_SETTING_SEQUENCE_LEN3,
+  SEQ_CHANNEL_SETTING_SEQUENCE_LEN4,
+  SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE,
+  SEQ_CHANNEL_SETTING_SEQUENCE_DIRECTION,
+  SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE_CV_RANGES,
+  SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION,
+  SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE,
+  SEQ_CHANNEL_SETTING_BROWNIAN_PROBABILITY,
+  // cv sources
+  SEQ_CHANNEL_SETTING_MULT_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_TRANSPOSE_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_PULSEWIDTH_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_OCTAVE_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_ROOT_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_OCTAVE_AUX_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_SEQ_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_SCALE_MASK_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_DIRECTION_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_BROWNIAN_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_LENGTH_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_ENV_ATTACK_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_ENV_DECAY_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_ENV_SUSTAIN_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_ENV_RELEASE_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_ENV_LOOPS_CV_SOURCE,
+  SEQ_CHANNEL_SETTING_DUMMY,
+  // aux envelope settings
+  SEQ_CHANNEL_SETTING_ENV_ATTACK_DURATION,
+  SEQ_CHANNEL_SETTING_ENV_ATTACK_SHAPE,
+  SEQ_CHANNEL_SETTING_ENV_DECAY_DURATION,
+  SEQ_CHANNEL_SETTING_ENV_DECAY_SHAPE,
+  SEQ_CHANNEL_SETTING_ENV_SUSTAIN_LEVEL,
+  SEQ_CHANNEL_SETTING_ENV_RELEASE_DURATION,
+  SEQ_CHANNEL_SETTING_ENV_RELEASE_SHAPE,
+  SEQ_CHANNEL_SETTING_ENV_MAX_LOOPS,
+  SEQ_CHANNEL_SETTING_ENV_ATTACK_RESET_BEHAVIOUR,
+  SEQ_CHANNEL_SETTING_ENV_ATTACK_FALLING_GATE_BEHAVIOUR,
+  SEQ_CHANNEL_SETTING_ENV_DECAY_RELEASE_RESET_BEHAVIOUR,
+  // marker
+  SEQ_CHANNEL_SETTING_LAST
+};
+
+enum SEQ_ChannelTriggerSource {
+  SEQ_CHANNEL_TRIGGER_TR1,
+  SEQ_CHANNEL_TRIGGER_TR2,
+  SEQ_CHANNEL_TRIGGER_NONE,
+  SEQ_CHANNEL_TRIGGER_FREEZE_HI2,
+  SEQ_CHANNEL_TRIGGER_FREEZE_LO2,
+  SEQ_CHANNEL_TRIGGER_FREEZE_HI4,
+  SEQ_CHANNEL_TRIGGER_FREEZE_LO4,
+  SEQ_CHANNEL_TRIGGER_LAST
+};
+
+enum SEQ_ChannelCV_Mapping {
+  CHANNEL_CV_MAPPING_CV1,
+  CHANNEL_CV_MAPPING_CV2,
+  CHANNEL_CV_MAPPING_CV3,
+  CHANNEL_CV_MAPPING_CV4,
+  CHANNEL_CV_MAPPING_LAST
+};
+
+enum SEQ_CLOCKSTATES {
+  OFF,
+  ON = 0xFFFF
+};
+
+enum MENU_PAGES {
+  PARAMETERS,
+  CV_MAPPING
+};
+
+enum SEQ_UPDATE {
+  ALL_OK,
+  WAIT,
+  CLEAR
+};
+
+enum PLAY_MODES {
+  PM_NONE,
+  PM_SEQ1,
+  PM_SEQ2,
+  PM_SEQ3,
+  PM_TR1,
+  PM_TR2,
+  PM_TR3,
+  PM_ARP,
+  PM_SH1,
+  PM_SH2,
+  PM_SH3,
+  PM_SH4,
+  PM_CV1,
+  PM_CV2,
+  PM_CV3,
+  PM_CV4,
+  PM_LAST
+};
+
+enum SEQ_DIRECTIONS {
+  FORWARD,
+  REVERSE,
+  PENDULUM1,
+  PENDULUM2,
+  RANDOM,
+  BROWNIAN,
+  SEQ_DIRECTIONS_LAST
+};
+
+enum SQ_AUX_MODES {
+  GATE_OUT,
+  COPY,
+  ENV_AD,
+  ENV_ADR,
+  ENV_ADSR,
+  SQ_AUX_MODES_LAST
+};
+
+uint64_t ext_frequency[SEQ_CHANNEL_TRIGGER_NONE + 1];
+
+class SEQ_Channel : public settings::SettingsBase<SEQ_Channel, SEQ_CHANNEL_SETTING_LAST> {
+public:
+
+  uint8_t get_menu_page() const {
+    return menu_page_;
+  }
+
+  bool octave_toggle() {
+    octave_toggle_ = (~octave_toggle_) & 1u;
+    return octave_toggle_;
+  }
+
+  bool poke_octave_toggle() const {
+    return octave_toggle_;
+  }
+
+  bool wait_for_EoS() {
+    return wait_for_EoS_;
+  }
+
+  void toggle_EoS() {
+    wait_for_EoS_ = (~wait_for_EoS_) & 1u;
+    apply_value(SEQ_CHANNEL_SETTING_DUMMY, wait_for_EoS_);
+  }
+
+  void set_EoS_update() {
+    wait_for_EoS_ = values_[SEQ_CHANNEL_SETTING_DUMMY];
+  }
+
+  void set_menu_page(uint8_t _menu_page) {
+    menu_page_ = _menu_page;
+  }
+
+  uint8_t get_aux_mode() const {
+    return values_[SEQ_CHANNEL_SETTING_MODE];
+  }
+
+  uint8_t get_root(uint8_t DUMMY) const {
+    return values_[SEQ_CHANNEL_SETTING_ROOT];
+  }
+
+  uint8_t get_clock_source() const {
+    return values_[SEQ_CHANNEL_SETTING_CLOCK];
+  }
+
+  uint16_t get_trigger_delay() const {
+    return values_[SEQ_CHANNEL_SETTING_TRIGGER_DELAY];
+  }
+
+  void set_clock_source(uint8_t _src) {
+    apply_value(SEQ_CHANNEL_SETTING_CLOCK, _src);
+  }
+
+  int get_octave() const {
+    return values_[SEQ_CHANNEL_SETTING_OCTAVE];
+  }
+
+  int get_octave_aux() const {
+    return values_[SEQ_CHANNEL_SETTING_OCTAVE_AUX];
+  }
+
+  int8_t get_multiplier() const {
+    return values_[SEQ_CHANNEL_SETTING_MULT];
+  }
+
+  uint16_t get_pulsewidth() const {
+    return values_[SEQ_CHANNEL_SETTING_PULSEWIDTH];
+  }
+
+  uint8_t get_reset_source() const {
+    return values_[SEQ_CHANNEL_SETTING_RESET];
+  }
+
+  void set_reset_source(uint8_t src) {
+    apply_value(SEQ_CHANNEL_SETTING_RESET, src);
+  }
+
+  int get_sequence() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE];
+  }
+
+  int get_current_sequence() const {
+    return display_num_sequence_;
+  }
+
+  int get_direction() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_DIRECTION];
+  }
+
+  int get_direction_cv() const {
+    return values_[SEQ_CHANNEL_SETTING_DIRECTION_CV_SOURCE];
+  }
+
+  int get_playmode() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE];
+  }
+
+  int draw_clock() const {
+    return get_playmode() != PM_ARP;
+  }
+
+  int get_arp_direction() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION];
+  }
+
+  int get_arp_range() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE];
+  }
+
+  int get_display_num_sequence() const {
+    return display_num_sequence_;
+  }
+
+  int get_display_length() const {
+    return active_sequence_length_;
+  }
+
+  void set_display_num_sequence(uint8_t seq) {
+    display_num_sequence_ = seq;
+  }
+
+  int get_display_mask() const {
+    return display_mask_;
+  }
+
+  void set_sequence(uint8_t seq) {
+    apply_value(SEQ_CHANNEL_SETTING_SEQUENCE, seq);
+  }
+
+  void set_gate(uint16_t _state) {
+    gate_state_ = _state;
+  }
+
+  uint8_t get_sequence_length(uint8_t _num_seq) const {
+
+    switch (_num_seq) {
+
+    case 0:
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_LEN1];
+    break;
+    case 1:
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_LEN2];
+    break;
+    case 2:
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_LEN3];
+    break;
+    case 3:
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_LEN4];
+    break;
+    default:
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_LEN1];
+    break;
+    }
+  }
+
+  uint8_t get_sequence_length_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_LENGTH_CV_SOURCE];
+  }
+
+  uint8_t get_mult_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_MULT_CV_SOURCE];
+  }
+
+  uint8_t get_transpose_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_TRANSPOSE_CV_SOURCE];
+  }
+
+  uint8_t get_pulsewidth_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_PULSEWIDTH_CV_SOURCE];
+  }
+
+  uint8_t get_scale_mask_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_SCALE_MASK_CV_SOURCE];
+  }
+
+  uint8_t get_sequence_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQ_CV_SOURCE];
+  }
+
+  uint8_t get_octave_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_OCTAVE_CV_SOURCE];
+  }
+
+  uint8_t get_root_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_ROOT_CV_SOURCE];
+  }
+
+  uint8_t get_octave_aux_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_OCTAVE_AUX_CV_SOURCE];
+  }
+
+  uint8_t get_arp_direction_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION_CV_SOURCE];
+  }
+
+  uint8_t get_arp_range_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE_CV_SOURCE];
+  }
+
+  uint8_t get_brownian_probability() const {
+    return values_[SEQ_CHANNEL_SETTING_BROWNIAN_PROBABILITY];
+  }
+
+  int8_t get_brownian_probability_cv() const {
+    return values_[SEQ_CHANNEL_SETTING_BROWNIAN_CV_SOURCE];
+  }
+
+  uint16_t get_attack_duration() const {
+    return SCALE8_16(values_[SEQ_CHANNEL_SETTING_ENV_ATTACK_DURATION]);
+  }
+
+  int8_t get_attack_duration_cv() const {
+    return values_[SEQ_CHANNEL_SETTING_ENV_ATTACK_CV_SOURCE];
+  }
+
+  peaks::EnvelopeShape get_attack_shape() const {
+    return static_cast<peaks::EnvelopeShape>(values_[SEQ_CHANNEL_SETTING_ENV_ATTACK_SHAPE]);
+  }
+
+  uint16_t get_decay_duration() const {
+    return SCALE8_16(values_[SEQ_CHANNEL_SETTING_ENV_DECAY_DURATION]);
+  }
+
+  int8_t get_decay_duration_cv() const {
+    return values_[SEQ_CHANNEL_SETTING_ENV_DECAY_CV_SOURCE];
+  }
+
+  peaks::EnvelopeShape get_decay_shape() const {
+    return static_cast<peaks::EnvelopeShape>(values_[SEQ_CHANNEL_SETTING_ENV_DECAY_SHAPE]);
+  }
+
+  uint16_t get_sustain_level() const {
+    return SCALE8_16(values_[SEQ_CHANNEL_SETTING_ENV_SUSTAIN_LEVEL]);
+  }
+
+  int8_t get_sustain_level_cv() const {
+    return values_[SEQ_CHANNEL_SETTING_ENV_SUSTAIN_CV_SOURCE];
+  }
+
+  uint16_t get_release_duration() const {
+    return SCALE8_16(values_[SEQ_CHANNEL_SETTING_ENV_RELEASE_DURATION]);
+  }
+
+  int8_t get_release_duration_cv() const {
+    return values_[SEQ_CHANNEL_SETTING_ENV_RELEASE_CV_SOURCE];
+  }
+
+  peaks::EnvelopeShape get_release_shape() const {
+    return static_cast<peaks::EnvelopeShape>(values_[SEQ_CHANNEL_SETTING_ENV_RELEASE_SHAPE]);
+  }
+
+  peaks::EnvResetBehaviour get_attack_reset_behaviour() const {
+    return static_cast<peaks::EnvResetBehaviour>(values_[SEQ_CHANNEL_SETTING_ENV_ATTACK_RESET_BEHAVIOUR]);
+  }
+
+  peaks::EnvFallingGateBehaviour get_attack_falling_gate_behaviour() const {
+    return static_cast<peaks::EnvFallingGateBehaviour>(values_[SEQ_CHANNEL_SETTING_ENV_ATTACK_FALLING_GATE_BEHAVIOUR]);
+  }
+
+  peaks::EnvResetBehaviour get_decay_release_reset_behaviour() const {
+    return static_cast<peaks::EnvResetBehaviour>(values_[SEQ_CHANNEL_SETTING_ENV_DECAY_RELEASE_RESET_BEHAVIOUR]);
+  }
+
+  uint16_t get_max_loops() const {
+    return values_[SEQ_CHANNEL_SETTING_ENV_MAX_LOOPS] << 9 ;
+  }
+
+  uint8_t get_env_loops_cv_source() const {
+    return values_[SEQ_CHANNEL_SETTING_ENV_LOOPS_CV_SOURCE];
+  }
+
+  void update_pattern_mask(uint16_t mask, uint8_t sequence) {
+
+    switch(sequence) {
+
+    case 1:
+      apply_value(SEQ_CHANNEL_SETTING_MASK2, mask);
+      break;
+    case 2:
+      apply_value(SEQ_CHANNEL_SETTING_MASK3, mask);
+      break;
+    case 3:
+      apply_value(SEQ_CHANNEL_SETTING_MASK4, mask);
+      break;
+    default:
+      apply_value(SEQ_CHANNEL_SETTING_MASK1, mask);
+      break;
+    }
+  }
+
+  int get_mask(uint8_t _this_num_sequence) const {
+
+    switch(_this_num_sequence) {
+
+    case 1:
+      return values_[SEQ_CHANNEL_SETTING_MASK2];
+      break;
+    case 2:
+      return values_[SEQ_CHANNEL_SETTING_MASK3];
+      break;
+    case 3:
+      return values_[SEQ_CHANNEL_SETTING_MASK4];
+      break;
+    default:
+      return values_[SEQ_CHANNEL_SETTING_MASK1];
+      break;
+    }
+  }
+
+  void set_sequence_length(uint8_t len, uint8_t seq) {
+
+    switch(seq) {
+      case 0:
+      apply_value(SEQ_CHANNEL_SETTING_SEQUENCE_LEN1, len);
+      break;
+      case 1:
+      apply_value(SEQ_CHANNEL_SETTING_SEQUENCE_LEN2, len);
+      break;
+      case 2:
+      apply_value(SEQ_CHANNEL_SETTING_SEQUENCE_LEN3, len);
+      break;
+      case 3:
+      apply_value(SEQ_CHANNEL_SETTING_SEQUENCE_LEN4, len);
+      break;
+      default:
+      break;
+    }
+  }
+
+  uint16_t get_clock_cnt() const {
+    return clk_cnt_;
+  }
+
+  uint32_t get_step_pitch() const {
+    return step_pitch_;
+  }
+
+  uint32_t get_step_pitch_aux() const {
+    return step_pitch_aux_;
+  }
+
+  uint32_t get_step_gate() const {
+    return gate_state_;
+  }
+
+  uint32_t get_step_state() const {
+    return step_state_;
+  }
+
+  int32_t get_pitch_at_step(uint8_t seq, uint8_t step) const {
+
+    uint8_t _channel_offset = !channel_id_ ? 0x0 : OC::Patterns::NUM_PATTERNS;
+
+    OC::Pattern *read_pattern_ = &OC::user_patterns[seq + _channel_offset];
+    return read_pattern_->notes[step];
+  }
+
+  void set_pitch_at_step(uint8_t seq, uint8_t step, int32_t pitch) {
+
+    uint8_t _channel_offset = !channel_id_ ? 0x0 : OC::Patterns::NUM_PATTERNS;
+
+    OC::Pattern *write_pattern_ = &OC::user_patterns[seq + _channel_offset];
+    write_pattern_->notes[step] = pitch;
+  }
+
+  uint16_t get_rotated_scale_mask() const {
+    return last_scale_mask_;
+  }
+
+  void clear_user_pattern(uint8_t seq) {
+
+    uint8_t _channel_offset = !channel_id_ ? 0x0 : OC::Patterns::NUM_PATTERNS;
+    memcpy(&OC::user_patterns[seq + _channel_offset], &OC::patterns[0], sizeof(OC::Pattern));
+  }
+
+  void copy_seq(uint8_t seq, uint8_t len, uint16_t mask) {
+
+    // which sequence ?
+    copy_sequence = seq + (!channel_id_ ? 0x0 : OC::Patterns::NUM_PATTERNS);
+    copy_length = len;
+    copy_mask = mask;
+    copy_timeout = 0;
+  }
+
+  uint8_t paste_seq(uint8_t seq) {
+
+    if (copy_timeout < COPYTIMEOUT) {
+
+       // which sequence to copy to ?
+       uint8_t sequence = seq + (!channel_id_ ? 0x0 : OC::Patterns::NUM_PATTERNS);
+       // copy length:
+       set_sequence_length(copy_length, seq);
+       // copy mask:
+       update_pattern_mask(copy_mask, seq);
+       // copy note values:
+       memcpy(&OC::user_patterns[sequence], &OC::user_patterns[copy_sequence], sizeof(OC::Pattern));
+       // give more time for more pasting...
+       copy_timeout = 0;
+
+       return copy_length;
+    }
+    else
+      return 0;
+  }
+
+  uint8_t getTriggerState() const {
+    return clock_display_.getState();
+  }
+
+  int num_enabled_settings() const {
+    return num_enabled_settings_;
+  }
+
+  void pattern_changed(uint16_t mask, bool force_update) {
+
+    force_update_ = force_update;
+    if (force_update)
+      display_mask_ = mask;
+
+    if (get_playmode() == PM_ARP) {
+      // update note stack
+      uint8_t seq = active_sequence_;
+      arpeggiator_.UpdateArpeggiator(channel_id_, seq, get_mask(seq), get_sequence_length(seq));
+    }
+  }
+
+  void sync() {
+    pending_sync_ = true;
+  }
+
+  void clear_CV_mapping() {
+    apply_value(SEQ_CHANNEL_SETTING_PULSEWIDTH_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_MULT_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_OCTAVE_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_ROOT_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_OCTAVE_AUX_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_SEQ_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_SCALE_MASK_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_TRANSPOSE_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_DIRECTION_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_BROWNIAN_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_LENGTH_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_ENV_ATTACK_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_ENV_DECAY_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_ENV_SUSTAIN_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_ENV_RELEASE_CV_SOURCE, 0);
+    apply_value(SEQ_CHANNEL_SETTING_ENV_LOOPS_CV_SOURCE, 0);
+  }
+
+  int get_scale(uint8_t dummy) const {
+    return values_[SEQ_CHANNEL_SETTING_SCALE];
+  }
+
+  void set_scale(int scale) {
+     apply_value(SEQ_CHANNEL_SETTING_SCALE, scale);
+  }
+
+  // dummy
+  int get_scale_select() const {
+    return 0;
+  }
+
+  // dummy
+  void set_scale_at_slot(int scale, uint16_t mask, int root, int transpose, uint8_t scale_slot) {
+
+  }
+
+  // dummy
+  int get_transpose(uint8_t DUMMY) const {
+    return 0;
+  }
+
+  int get_scale_mask(uint8_t scale_select) const {
+    return values_[SEQ_CHANNEL_SETTING_SCALE_MASK];
+  }
+
+  void scale_changed() {
+    force_scale_update_ = true;
+  }
+
+  void update_scale_mask(uint16_t mask, uint16_t dummy) {
+    force_scale_update_ = true;
+    apply_value(SEQ_CHANNEL_SETTING_SCALE_MASK, mask); // Should automatically be updated
+  }
+
+  void update_inputmap(int num_slots, uint8_t range) {
+    input_map_.Configure(OC::InputMaps::GetInputMap(num_slots), range);
+  }
+
+  int get_cv_input_range() const {
+    return values_[SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE_CV_RANGES];
+  }
+
+  void Init(SEQ_ChannelTriggerSource trigger_source, uint8_t id) {
+
+    InitDefaults();
+    trigger_delay_.Init();
+    channel_id_ = id;
+    octave_toggle_ = false;
+    wait_for_EoS_ = false;
+    note_repeat_ = false;
+    menu_page_ = PARAMETERS;
+    apply_value(SEQ_CHANNEL_SETTING_CLOCK, trigger_source);
+    quantizer_.Init();
+    quantizer_.Requantize();
+    input_map_.Init();
+    env_.Init();
+    force_update_ = true;
+    force_scale_update_ = true;
+    gate_state_ = step_state_ = OFF;
+    step_pitch_ = 0;
+    step_pitch_aux_ = 0;
+    subticks_ = 0;
+    tickjitter_ = 10000;
+    clk_cnt_ = 0;
+    clk_src_ = get_clock_source();
+    prev_reset_state_ = false;
+    reset_pending_ = false;
+    prev_multiplier_ = get_multiplier();
+    prev_pulsewidth_ = get_pulsewidth();
+    prev_input_range_ = 0;
+    prev_playmode_ = get_playmode();
+    pending_sync_ = false;
+    sequence_change_pending_ = 0x0;
+    prev_gate_raised_ = 0 ;
+    env_gate_raised_ = 0 ;
+    env_gate_state_ = 0 ;
+
+    ext_frequency_in_ticks_ = 0xFFFFFFFF;
+    channel_frequency_in_ticks_ = 0xFFFFFFFF;
+    pulse_width_in_ticks_ = get_pulsewidth() << 10;
+
+    display_num_sequence_ = get_sequence();
+    display_mask_ = get_mask(display_num_sequence_);
+    active_sequence_ = display_num_sequence_;
+    sequence_manual_ = display_num_sequence_;
+    sequence_advance_state_ = false;
+    pendulum_fwd_ = true;
+    uint32_t _seed = OC::ADC::value<ADC_CHANNEL_1>() + OC::ADC::value<ADC_CHANNEL_2>() + OC::ADC::value<ADC_CHANNEL_3>() + OC::ADC::value<ADC_CHANNEL_4>();
+    randomSeed(_seed);
+    clock_display_.Init();
+    arpeggiator_.Init();
+    update_enabled_settings(0);
+  }
+
+  bool rotate_scale(int32_t mask_rotate) {
+
+    uint16_t  scale_mask = get_scale_mask(DUMMY);
+    const int scale = get_scale(DUMMY);
+
+    if (mask_rotate)
+      scale_mask = OC::ScaleEditor<SEQ_Channel>::RotateMask(scale_mask, OC::Scales::GetScale(scale).num_notes, mask_rotate);
+
+    if (last_scale_mask_ != scale_mask) {
+
+      force_scale_update_ = false;
+      last_scale_ = scale;
+      last_scale_mask_ = scale_mask;
+      quantizer_.Configure(OC::Scales::GetScale(scale), scale_mask);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  bool update_scale(bool force) {
+
+    const int scale = get_scale(DUMMY);
+
+    if (force || last_scale_ != scale) {
+
+      uint16_t  scale_mask = get_scale_mask(DUMMY);
+      force_scale_update_ = false;
+      last_scale_ = scale;
+      last_scale_mask_ = scale_mask;
+      quantizer_.Configure(OC::Scales::GetScale(scale), scale_mask);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void force_update() {
+    force_update_ = true;
+  }
+
+  bool update_timeout() {
+    // wait for ~ 1.5 sec
+    return (subticks_ > 30000) ? true : false;
+  }
+
+  /* main channel update below: */
+
+  inline void Update(uint32_t triggers, DAC_CHANNEL dac_channel) {
+
+     // increment channel ticks ..
+     subticks_++;
+
+     int8_t _clock_source, _reset_source = 0x0, _aux_mode, _playmode;
+     int8_t _multiplier = 0x0;
+     bool _none, _triggered, _tock, _sync, _continuous;
+     uint32_t _subticks = 0x0, prev_channel_frequency_in_ticks_ = 0x0;
+
+     // core channel parameters --
+     // 1. clock source:
+     _clock_source = get_clock_source();
+
+     // 2. sequencer aux channel / play modes -
+     _aux_mode = get_aux_mode();
+     _playmode = get_playmode();
+     _continuous = _playmode >= PM_SH1 ? true : false;
+
+     // 3. update scale?
+     update_scale(force_scale_update_);
+
+     // clocked ?
+     _none = SEQ_CHANNEL_TRIGGER_NONE == _clock_source;
+     // TR1 or TR3?
+     _triggered = _clock_source ? (!_none && (triggers & (1 << OC::DIGITAL_INPUT_3))) : (!_none && (triggers & (1 << OC::DIGITAL_INPUT_1)));
+     _tock = false;
+     _sync = false;
+
+     // trigger delay:
+     if (_playmode < PM_SH1) {
+
+      trigger_delay_.Update();
+      if (_triggered)
+        trigger_delay_.Push(OC::trigger_delay_ticks[get_trigger_delay()]);
+        _triggered = trigger_delay_.triggered();
+     }
+
+     // new tick frequency:
+     if (_clock_source <= SEQ_CHANNEL_TRIGGER_TR2) {
+
+         if (_triggered || clk_src_ != _clock_source) {
+            ext_frequency_in_ticks_ = ext_frequency[_clock_source];
+            _tock = true;
+            div_cnt_--;
+         }
+     }
+     // store clock source:
+     clk_src_ = _clock_source;
+
+     if (!_continuous) {
+
+         _multiplier = get_multiplier();
+
+         if (get_mult_cv_source()) {
+            _multiplier += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_mult_cv_source() - 1)) + 127) >> 8;
+            CONSTRAIN(_multiplier, 0, MULT_MAX);
+         }
+
+         // new multiplier ?
+         if (prev_multiplier_ != _multiplier)
+           _tock |= true;
+         prev_multiplier_ = _multiplier;
+
+         // if so, recalculate channel frequency and corresponding jitter-thresholds:
+         if (_tock) {
+
+            // when multiplying, skip too closely spaced triggers:
+            if (_multiplier > MULT_BY_ONE) {
+               prev_channel_frequency_in_ticks_ = multiply_u32xu32_rshift32(channel_frequency_in_ticks_, TICK_SCALE);
+               // new frequency:
+               channel_frequency_in_ticks_ = multiply_u32xu32_rshift32(ext_frequency_in_ticks_, multipliers_[_multiplier-MULT_BY_ONE]);
+            }
+            else {
+               prev_channel_frequency_in_ticks_ = 0x0;
+               // new frequency (used for pulsewidth):
+               channel_frequency_in_ticks_ = multiply_u32xu32_rshift32(ext_frequency_in_ticks_, pw_scale_[_multiplier]) << 6;
+            }
+
+            tickjitter_ = multiply_u32xu32_rshift32(channel_frequency_in_ticks_, TICK_JITTER);
+         }
+         // limit frequency to > 0
+         if (!channel_frequency_in_ticks_)
+            channel_frequency_in_ticks_ = 1u;
+
+         // reset?
+         _reset_source = get_reset_source();
+
+         if (_reset_source < SEQ_CHANNEL_TRIGGER_NONE && !reset_pending_) {
+
+            uint8_t reset_state_ = !_reset_source ? digitalReadFast(TR2) : digitalReadFast(TR4); // TR1, TR3 are main clock sources
+
+            // ?
+            if (reset_state_ < prev_reset_state_) {
+               div_cnt_ = 0x0;
+               reset_pending_ = true; // reset clock counter below
+            }
+            prev_reset_state_ = reset_state_;
+         }
+
+        /*
+         *  brute force ugly sync hack:
+         *  this, presumably, is needlessly complicated.
+         *  but seems to work ok-ish, w/o too much jitter and missing clocks...
+         */
+
+         _subticks = subticks_;
+         // sync? (manual)
+         div_cnt_ = pending_sync_ ? 0x0 : div_cnt_;
+
+         if (_multiplier <= MULT_BY_ONE && _triggered && div_cnt_ <= 0) {
+            // division, so we track
+            _sync = true;
+            div_cnt_ = divisors_[_multiplier];
+            subticks_ = channel_frequency_in_ticks_; // force sync
+         }
+         else if (_multiplier <= MULT_BY_ONE && _triggered) {
+            // division, mute output:
+            step_state_ = OFF;
+         }
+         else if (_multiplier > MULT_BY_ONE && _triggered)  {
+            // multiplication, force sync, if clocked:
+            _sync = true;
+            subticks_ = channel_frequency_in_ticks_;
+         }
+         else if (_multiplier > MULT_BY_ONE)
+            _sync = true;
+         // end of ugly hack
+     }
+     else {
+     // S+H mode
+        if (_playmode <= PM_SH4) {
+
+          if (_triggered) {
+            // new frequency (used for pulsewidth):
+            channel_frequency_in_ticks_ = ext_frequency_in_ticks_;
+            subticks_ = 0x0;
+          }
+          else
+            // don't trigger, if no trigger - see below
+            _continuous = _sync = false;
+        }
+     }
+
+     // time to output ?
+     if ((subticks_ >= channel_frequency_in_ticks_ && _sync) || _continuous) {
+
+         if (!_continuous) {
+           // reset ticks
+           subticks_ = 0x0;
+           //reject, if clock is too jittery or skip quasi-double triggers when ext. frequency increases:
+           if (_subticks < tickjitter_ || (_subticks < prev_channel_frequency_in_ticks_ && !reset_pending_))
+              return;
+         }
+
+         // resync/clear pending sync
+         if (_triggered && pending_sync_) {
+          pending_sync_ = false;
+          clk_cnt_ = 0x0;
+         }
+
+         // mute output ?
+         bool mute = 0;
+
+         switch (_reset_source) {
+
+             case SEQ_CHANNEL_TRIGGER_TR1:
+             case SEQ_CHANNEL_TRIGGER_TR2:
+             case SEQ_CHANNEL_TRIGGER_NONE:
+             break;
+             case SEQ_CHANNEL_TRIGGER_FREEZE_HI2:
+              mute = !digitalReadFast(TR2);
+             break;
+             case SEQ_CHANNEL_TRIGGER_FREEZE_LO2:
+              mute = digitalReadFast(TR2);
+             break;
+             case SEQ_CHANNEL_TRIGGER_FREEZE_HI4:
+              mute = !digitalReadFast(TR4);
+             break;
+             case SEQ_CHANNEL_TRIGGER_FREEZE_LO4:
+              mute = digitalReadFast(TR4);
+             break;
+             default:
+             break;
+         }
+
+         if (mute)
+           return;
+
+         // mask CV ?
+         if (get_scale_mask_cv_source()) {
+            int16_t _rotate = (OC::ADC::value(static_cast<ADC_CHANNEL>(get_scale_mask_cv_source() - 1)) + 127) >> 8;
+            rotate_scale(_rotate);
+         }
+
+         // finally, process trigger + output:
+         if (process_num_seq_channel(_playmode, reset_pending_)) {
+
+            // turn on gate
+            gate_state_ = ON;
+
+            int8_t _octave = get_octave();
+            if (get_octave_cv_source())
+              _octave += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_octave_cv_source() - 1)) + 255) >> 9;
+
+            int8_t _transpose = 0x0;
+            if (get_transpose_cv_source()) {
+              _transpose += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_transpose_cv_source() - 1)) + 64) >> 7;
+              CONSTRAIN(_transpose, -12, 12);
+            }
+
+            int8_t _root = get_root(0x0);
+            if (get_root_cv_source()) {
+              _root += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_root_cv_source() - 1)) + 127) >> 8;
+              CONSTRAIN(_root, 0, 11);
+            }
+
+            if (_playmode != PM_ARP) {
+              // use the current sequence, updated in process_num_seq_channel():
+              step_pitch_ = get_pitch_at_step(display_num_sequence_, clk_cnt_) + (_octave * 12 << 7);
+            }
+            else {
+
+              int8_t arp_range = get_arp_range();
+              if (get_arp_range_cv_source()) {
+                arp_range += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_arp_range_cv_source() - 1)) + 255) >> 9;
+                CONSTRAIN(arp_range, 0, 4);
+              }
+              arpeggiator_.set_range(arp_range);
+
+              int8_t arp_direction = get_arp_direction();
+              if (get_arp_direction_cv_source()) {
+                arp_direction += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_arp_direction_cv_source() - 1)) + 255) >> 9;
+                CONSTRAIN(arp_direction, 0, 4);
+              }
+              arpeggiator_.set_direction(arp_direction);
+
+              step_pitch_ = arpeggiator_.ClockArpeggiator() + (_octave * 12 << 7);
+              // mute ?
+              if (step_pitch_ == 0xFFFFFF)
+                gate_state_ = step_state_ = OFF;
+            }
+            // update output:
+            step_pitch_ = quantizer_.Process(step_pitch_, _root << 7, _transpose);
+
+            int32_t _attack = get_attack_duration();
+            int32_t _decay = get_decay_duration();
+            int32_t _sustain = get_sustain_level();
+            int32_t _release = get_release_duration();
+            int32_t _loops = get_max_loops();
+
+            switch (_aux_mode) {
+                case ENV_AD:
+                case ENV_ADR:
+                case ENV_ADSR:
+                  if (get_attack_duration_cv()) {
+                    _attack += OC::ADC::value(static_cast<ADC_CHANNEL>(get_attack_duration_cv() - 1)) << 3;
+                    USAT16(_attack) ;
+                  }
+                  if (get_decay_duration_cv()) {
+                    _decay += OC::ADC::value(static_cast<ADC_CHANNEL>(get_decay_duration_cv() - 1)) << 3;
+                    USAT16(_decay);
+                  }
+                  if (get_sustain_level_cv()) {
+                    _sustain += OC::ADC::value(static_cast<ADC_CHANNEL>(get_sustain_level_cv() - 1)) << 4;
+                    CONSTRAIN(_sustain, 0, 65534);
+                  }
+                  if (get_release_duration_cv()) {
+                    _release += OC::ADC::value(static_cast<ADC_CHANNEL>(get_release_duration_cv() - 1)) << 3;
+                    USAT16(_release) ;
+                  }
+                  if (get_env_loops_cv_source()) {
+                    _loops += OC::ADC::value(static_cast<ADC_CHANNEL>(get_env_loops_cv_source() - 1)) ;
+                    CONSTRAIN(_loops,1<<8, 65534) ;
+                  }
+                  // set the specified reset behaviours
+                  env_.set_attack_reset_behaviour(get_attack_reset_behaviour());
+                  env_.set_attack_falling_gate_behaviour(get_attack_falling_gate_behaviour());
+                  env_.set_decay_release_reset_behaviour(get_decay_release_reset_behaviour());
+                  // set number of loops
+                  env_.set_max_loops(_loops);
+                break;
+                default:
+                break;
+            }
+
+            switch (_aux_mode) {
+
+                case COPY:
+                {
+                  int8_t _octave_aux = _octave + get_octave_aux();
+                  if (get_octave_aux_cv_source())
+                    _octave_aux += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_octave_aux_cv_source() - 1)) + 255) >> 9;
+
+                  if (_playmode != PM_ARP)
+                    step_pitch_aux_ = get_pitch_at_step(display_num_sequence_, clk_cnt_) + (_octave_aux * 12 << 7);
+                  else
+                  // this *might* not be quite a copy...
+                    step_pitch_aux_ = step_pitch_ + (_octave_aux * 12 << 7);
+                  step_pitch_aux_ = quantizer_.Process(step_pitch_aux_, _root << 7, _transpose);
+                }
+                break;
+                case ENV_AD:
+                {
+                  env_.set_ad(_attack, _decay, 0, 2);
+                  env_.set_attack_shape(get_attack_shape());
+                  env_.set_decay_shape(get_decay_shape());
+                }
+                break;
+                case ENV_ADR:
+                {
+                  env_.set_adr(_attack, _decay, _sustain >> 1, _release, 0, 2);
+                  env_.set_attack_shape(get_attack_shape());
+                  env_.set_decay_shape(get_decay_shape());
+                  env_.set_release_shape(get_release_shape());
+                }
+                break;
+                case ENV_ADSR:
+                {
+                  env_.set_adsr(_attack, _decay, _sustain >> 1, _release);
+                  env_.set_attack_shape(get_attack_shape());
+                  env_.set_decay_shape(get_decay_shape());
+                  env_.set_release_shape(get_release_shape());
+                }
+                break;
+                default:
+                break;
+            }
+         }
+         // clear for reset:
+         reset_pending_ = false;
+     }
+
+     /*
+      *  below: pulsewidth stuff
+      */
+
+     if (_aux_mode != COPY && gate_state_) {
+
+        // pulsewidth setting --
+        int16_t _pulsewidth = get_pulsewidth();
+        bool _we_cannot_echo = _playmode >= PM_CV1 ? true : false;
+
+        if (_pulsewidth || _multiplier > MULT_BY_ONE || _we_cannot_echo) {
+
+            bool _gates = false;
+
+            // do we echo && multiply? if so, do half-duty cycle:
+            if (!_pulsewidth)
+                _pulsewidth = PULSEW_MAX;
+
+            if (_pulsewidth == PULSEW_MAX)
+              _gates = true;
+            // CV?
+            if (get_pulsewidth_cv_source()) {
+
+              _pulsewidth += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_pulsewidth_cv_source() - 1)) + 4) >> 3;
+              if (!_gates)
+                CONSTRAIN(_pulsewidth, 1, PULSEW_MAX);
+              else // CV for 50% duty cycle:
+                CONSTRAIN(_pulsewidth, 1, (PULSEW_MAX<<1) - 55);  // incl margin, max < 2x mult. see below
+            }
+            // recalculate (in ticks), if new pulsewidth setting:
+            if (prev_pulsewidth_ != _pulsewidth || ! subticks_) {
+                if (!_gates || _we_cannot_echo) {
+                  int32_t _fraction = signed_multiply_32x16b(TICKS_TO_MS, static_cast<int32_t>(_pulsewidth)); // = * 0.6667f
+                  _fraction = signed_saturate_rshift(_fraction, 16, 0);
+                  pulse_width_in_ticks_  = (_pulsewidth << 4) + _fraction;
+                }
+                else { // put out gates/half duty cycle:
+                  pulse_width_in_ticks_ = channel_frequency_in_ticks_ >> 1;
+
+                  if (_pulsewidth != PULSEW_MAX) { // CV?
+                    pulse_width_in_ticks_ = signed_multiply_32x16b(static_cast<int32_t>(_pulsewidth) << 8, pulse_width_in_ticks_); //
+                    pulse_width_in_ticks_ = signed_saturate_rshift(pulse_width_in_ticks_, 16, 0);
+                  }
+                }
+            }
+            prev_pulsewidth_ = _pulsewidth;
+
+            // limit pulsewidth, if approaching half duty cycle:
+            if (!_gates && pulse_width_in_ticks_ >= channel_frequency_in_ticks_>>1)
+              pulse_width_in_ticks_ = (channel_frequency_in_ticks_ >> 1) | 1u;
+
+            // turn off output?
+            if (subticks_ >= pulse_width_in_ticks_)
+              gate_state_ = OFF;
+            else // keep on
+              gate_state_ = ON;
+         }
+         else {
+            // we simply echo the pulsewidth:
+            bool _state = (_clock_source == SEQ_CHANNEL_TRIGGER_TR1) ? !digitalReadFast(TR1) : !digitalReadFast(TR3);
+
+            if (_state)
+              gate_state_ = ON;
+            else
+              gate_state_ = OFF;
+         }
+     }
+  } // end update
+
+  /* details re: sequence processing happens (mostly) here: */
+  inline bool process_num_seq_channel(uint8_t playmode, uint8_t reset) {
+
+      bool _out = true;
+      bool _change = true;
+      bool _reset = reset;
+      int8_t _playmode, sequence_max, sequence_cnt, _num_seq, num_sequence_cv, sequence_length, sequence_length_cv;
+
+      _num_seq = get_sequence();
+      _playmode = playmode;
+      sequence_max = 0x0;
+      sequence_cnt = 0x0;
+      num_sequence_cv = 0x0;
+      sequence_length = 0x0;
+      sequence_length_cv = 0x0;
+
+      if (_num_seq != sequence_manual_) {
+        // setting changed ...
+        if (!wait_for_EoS_) {
+          _reset = true;
+          if (_playmode >= PM_TR1 && _playmode <= PM_TR3)
+            active_sequence_ = _num_seq;
+        }
+        else if (_playmode < PM_SH1)
+          sequence_change_pending_ = WAIT;
+      }
+      sequence_manual_ = _num_seq;
+
+      if (sequence_change_pending_ == WAIT)
+        _num_seq = active_sequence_;
+      else if (sequence_change_pending_ == CLEAR) {
+        _reset = true;
+        sequence_change_pending_ = ALL_OK;
+        if (_playmode >= PM_TR1 && _playmode <= PM_TR3)
+            active_sequence_ = _num_seq;
+      }
+
+      if (get_sequence_cv_source()) {
+        num_sequence_cv = _num_seq += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_sequence_cv_source() - 1)) + 255) >> 9;
+        CONSTRAIN(_num_seq, 0, OC::Patterns::PATTERN_USER_LAST - 0x1);
+      }
+
+      if (get_sequence_length_cv_source())
+        sequence_length_cv = (OC::ADC::value(static_cast<ADC_CHANNEL>(get_sequence_length_cv_source() - 1)) + 64) >> 7;
+
+      switch (_playmode) {
+
+        case PM_NONE:
+        active_sequence_ = _num_seq;
+        break;
+        case PM_ARP:
+        sequence_change_pending_ = ALL_OK;
+        sequence_length = get_sequence_length(_num_seq) + sequence_length_cv;
+        CONSTRAIN(sequence_length, OC::Patterns::kMin, OC::Patterns::kMax);
+
+        if (active_sequence_ != _num_seq || sequence_length != active_sequence_length_ || prev_playmode_ != _playmode)
+          arpeggiator_.UpdateArpeggiator(channel_id_, _num_seq, get_mask(_num_seq), sequence_length);
+        active_sequence_ = _num_seq;
+        active_sequence_length_ = sequence_length;
+        if (_reset)
+          arpeggiator_.reset();
+        prev_playmode_ = _playmode;
+        // and skip the stuff below:
+        _playmode = 0xFF;
+        break;
+        case PM_SEQ1:
+        case PM_SEQ2:
+        case PM_SEQ3:
+        {
+         // concatenate sequences:
+         sequence_max = _playmode;
+
+              if (sequence_EoS_) {
+
+                // increment sequence #
+                sequence_cnt_ += sequence_EoS_;
+                // reset sequence #
+                sequence_cnt_ = sequence_cnt_ > sequence_max ? 0x0 : sequence_cnt_;
+                // update
+                active_sequence_ = _num_seq + sequence_cnt_;
+                // wrap around:
+                if (active_sequence_ >= OC::Patterns::PATTERN_USER_LAST)
+                    active_sequence_ -= OC::Patterns::PATTERN_USER_LAST;
+                // reset
+                _clock(get_sequence_length(active_sequence_), 0x0, sequence_max, true);
+                _reset = true;
+              }
+              else if (num_sequence_cv)  {
+                active_sequence_ += num_sequence_cv;
+                CONSTRAIN(active_sequence_, 0, OC::Patterns::PATTERN_USER_LAST - 1);
+              }
+              sequence_cnt = sequence_cnt_;
+        }
+        break;
+        case PM_TR1:
+        case PM_TR2:
+        case PM_TR3:
+        {
+          sequence_max = _playmode - PM_SEQ3;
+          prev_playmode_ = _playmode;
+          // trigger?
+          uint8_t _advance_trig = (channel_id_ == DAC_CHANNEL_A) ? digitalReadFast(TR2) : digitalReadFast(TR4);
+
+          if (_advance_trig < sequence_advance_state_) {
+
+            // increment sequence #
+            sequence_cnt_++;
+            // reset sequence #
+            sequence_cnt_ = sequence_cnt_ > sequence_max ? 0x0 : sequence_cnt_;
+            // update
+            active_sequence_ = _num_seq + sequence_cnt_;
+            // + reset
+            _reset = true;
+            // wrap around:
+            if (active_sequence_ >= OC::Patterns::PATTERN_USER_LAST)
+                active_sequence_ -= OC::Patterns::PATTERN_USER_LAST;
+          }
+          else if (num_sequence_cv)  {
+              active_sequence_ += num_sequence_cv;
+              CONSTRAIN(active_sequence_, 0, OC::Patterns::PATTERN_USER_LAST - 1);
+          }
+          sequence_advance_state_ = _advance_trig;
+          sequence_max = 0x0;
+        }
+        break;
+        case PM_SH1:
+        case PM_SH2:
+        case PM_SH3:
+        case PM_SH4:
+        {
+           int input_range;
+           sequence_length = get_sequence_length(_num_seq) + sequence_length_cv;
+           CONSTRAIN(sequence_length, OC::Patterns::kMin, OC::Patterns::kMax);
+           input_range =  get_cv_input_range();
+
+           // length or range changed ?
+           if (active_sequence_length_ != sequence_length || input_range != prev_input_range_ || prev_playmode_ != _playmode)
+              update_inputmap(sequence_length, input_range);
+           // store values:
+           active_sequence_ = _num_seq;
+           active_sequence_length_ = sequence_length;
+           prev_input_range_ = input_range;
+           prev_playmode_ = _playmode;
+
+           // process input:
+           if (!input_range)
+              clk_cnt_ = input_map_.Process(OC::ADC::value(static_cast<ADC_CHANNEL>(_playmode - PM_SH1)));
+           else
+              clk_cnt_ = input_map_.Process(0xFFF - OC::ADC::smoothed_raw_value(static_cast<ADC_CHANNEL>(_playmode - PM_SH1)));
+        }
+        break;
+        case PM_CV1:
+        case PM_CV2:
+        case PM_CV3:
+        case PM_CV4:
+        {
+           int input_range;
+           sequence_length = get_sequence_length(_num_seq) + sequence_length_cv;
+           CONSTRAIN(sequence_length, OC::Patterns::kMin, OC::Patterns::kMax);
+           input_range =  get_cv_input_range();
+           // length changed ?
+           if (active_sequence_length_ != sequence_length || input_range != prev_input_range_ || prev_playmode_ != _playmode)
+              update_inputmap(sequence_length, input_range);
+           // store values:
+           active_sequence_length_ = sequence_length;
+           prev_input_range_ = input_range;
+           active_sequence_ = _num_seq;
+           prev_playmode_ = _playmode;
+
+           // process input:
+           if (!input_range)
+              clk_cnt_ = input_map_.Process(OC::ADC::value(static_cast<ADC_CHANNEL>(_playmode - PM_CV1))); // = 5V
+           else
+              clk_cnt_ = input_map_.Process(0xFFF - OC::ADC::smoothed_raw_value(static_cast<ADC_CHANNEL>(_playmode - PM_CV1))); // = 10V
+
+           // update output, if slot # changed:
+           if (prev_slot_ == clk_cnt_)
+             _change = false;
+           else {
+              subticks_ = 0x0;
+              prev_slot_ = clk_cnt_;
+           }
+        }
+        break;
+        default:
+        break;
+      }
+      // end switch
+
+      _num_seq = active_sequence_;
+
+      if (_playmode < PM_SH1) {
+
+        sequence_length = get_sequence_length(_num_seq) + sequence_length_cv;
+        if (sequence_length_cv)
+            CONSTRAIN(sequence_length, OC::Patterns::kMin, OC::Patterns::kMax);
+
+        CONSTRAIN(clk_cnt_, 0x0, sequence_length);
+        sequence_EoS_ = _clock(sequence_length - 0x1, sequence_cnt, sequence_max, _reset);
+      }
+
+      // this is the current sequence # (USER1-USER4):
+      display_num_sequence_ = _num_seq;
+      // and corresponding pattern mask:
+      display_mask_ = get_mask(_num_seq);
+      // ... and the length
+      active_sequence_length_ = sequence_length;
+
+      // slot at current position:
+      if (_playmode != PM_ARP) {
+        _out = (display_mask_ >> clk_cnt_) & 1u;
+        step_state_ = _out ? ON : OFF;
+        _out = (_out && _change) ? true : false;
+      }
+      else {
+         step_state_ = ON;
+         clk_cnt_ = 0x0;
+      }
+      // return step:
+      return _out;
+  }
+
+  // update sequencer clock, return -1, 0, 1 when EoS is reached:
+
+  int8_t _clock(uint8_t sequence_length, uint8_t sequence_count, uint8_t sequence_max, bool _reset) {
+
+    int8_t EoS = 0x0, _clk_cnt, _direction;
+    bool reset = _reset;
+
+    _clk_cnt = clk_cnt_;
+    _direction = get_direction();
+
+    if (get_direction_cv()) {
+       _direction += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_direction_cv() - 1)) + 255) >> 9;
+       CONSTRAIN(_direction, 0, SEQ_DIRECTIONS_LAST - 0x1);
+    }
+
+    switch (_direction) {
+
+      case FORWARD:
+      {
+        _clk_cnt++;
+        if (reset)
+          _clk_cnt = 0x0;
+        // end of sequence?
+        else if (_clk_cnt > sequence_length)
+          _clk_cnt = 0x0;
+        else if (_clk_cnt == sequence_length) {
+           EoS = 0x1;
+        }
+      }
+      break;
+      case REVERSE:
+      {
+        _clk_cnt--;
+        if (reset)
+          _clk_cnt = sequence_length;
+        // end of sequence?
+        else if (_clk_cnt < 0)
+          _clk_cnt = sequence_length;
+        else if (!_clk_cnt)
+           EoS = 0x1;
+      }
+      break;
+      case PENDULUM1:
+      case BROWNIAN:
+      if (BROWNIAN == _direction) {
+        // Compare Brownian probability and reverse direction if needed
+        int16_t brown_prb = get_brownian_probability();
+
+        if (get_brownian_probability_cv()) {
+          brown_prb += (OC::ADC::value(static_cast<ADC_CHANNEL>(get_brownian_probability_cv() - 1)) + 8) >> 3;
+          CONSTRAIN(brown_prb, 0, 256);
+        }
+        if (random(0,256) < brown_prb)
+          pendulum_fwd_ = !pendulum_fwd_;
+      }
+      {
+        if (pendulum_fwd_) {
+          _clk_cnt++;
+          if (reset)
+            _clk_cnt = 0x0;
+          else if (_clk_cnt >= sequence_length) {
+
+            if (sequence_count >= sequence_max) {
+              pendulum_fwd_ = false;
+              _clk_cnt = sequence_length;
+            }
+            else EoS = 0x1;
+            // pendulum needs special care (when PM_NONE)
+            if (!pendulum_fwd_ && sequence_change_pending_ == WAIT) sequence_change_pending_ = CLEAR;
+          }
+        }
+        // reverse direction:
+        else {
+          _clk_cnt--;
+          if (reset)
+            _clk_cnt = sequence_length;
+          else if (_clk_cnt <= 0) {
+            // end of sequence ?
+            if (sequence_count == 0x0) {
+              pendulum_fwd_ = true;
+              _clk_cnt = 0x0;
+            }
+            else EoS = -0x1;
+            if (pendulum_fwd_ && sequence_change_pending_ == WAIT) sequence_change_pending_ = CLEAR;
+          }
+        }
+      }
+      break;
+      case PENDULUM2:
+      {
+        if (pendulum_fwd_) {
+
+          if (!note_repeat_)
+            _clk_cnt++;
+          note_repeat_ = false;
+
+          if (reset)
+            _clk_cnt = 0x0;
+          else if (_clk_cnt >= sequence_length) {
+            // end of sequence ?
+            if (sequence_count >= sequence_max) {
+              pendulum_fwd_ = false;
+              _clk_cnt = sequence_length;
+              note_repeat_ = true; // repeat last step
+            }
+            else EoS = 0x1;
+            if (!pendulum_fwd_ && sequence_change_pending_ == WAIT) sequence_change_pending_ = CLEAR;
+          }
+        }
+        // reverse direction:
+        else {
+
+          if (!note_repeat_)
+            _clk_cnt--;
+          note_repeat_ = false;
+
+          if (reset)
+            _clk_cnt = sequence_length;
+          else if (_clk_cnt <= 0x0) {
+            // end of sequence ?
+            if (sequence_count == 0x0) {
+              pendulum_fwd_ = true;
+              _clk_cnt = 0x0;
+              note_repeat_ = true; // repeat first step
+            }
+            else EoS = -0x1;
+            if (pendulum_fwd_ && sequence_change_pending_ == WAIT) sequence_change_pending_ = CLEAR;
+          }
+        }
+      }
+      break;
+      case RANDOM:
+      _clk_cnt = random(sequence_length + 0x1);
+      if (reset)
+        _clk_cnt = 0x0;
+      // jump to next sequence if we happen to hit the last note:
+      else if (_clk_cnt >= sequence_length)
+        EoS = random(0x2);
+      break;
+      default:
+      break;
+    }
+    clk_cnt_ = _clk_cnt;
+
+    if (EoS && sequence_change_pending_ == WAIT) sequence_change_pending_ = CLEAR;
+    return EoS;
+  }
+
+  SEQ_ChannelSetting enabled_setting_at(int index) const {
+    return enabled_settings_[index];
+  }
+
+  void update_enabled_settings(uint8_t channel_id) {
+
+    SEQ_ChannelSetting *settings = enabled_settings_;
+
+    switch(get_menu_page()) {
+
+      case PARAMETERS: {
+
+          *settings++ = SEQ_CHANNEL_SETTING_SCALE;
+          *settings++ = SEQ_CHANNEL_SETTING_SCALE_MASK;
+          *settings++ = SEQ_CHANNEL_SETTING_SEQUENCE;
+
+          switch (get_sequence()) {
+
+            case 0:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK1;
+            break;
+            case 1:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK2;
+            break;
+            case 2:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK3;
+            break;
+            case 3:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK4;
+            break;
+            default:
+            break;
+          }
+
+         *settings++ = SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE;
+
+         if (get_playmode() < PM_SH1) {
+
+             *settings++ = (get_playmode() == PM_ARP) ? SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION : SEQ_CHANNEL_SETTING_SEQUENCE_DIRECTION;
+             if (get_playmode() == PM_ARP)
+               *settings++ = SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE;
+             else if (get_direction() == BROWNIAN)
+               *settings++ = SEQ_CHANNEL_SETTING_BROWNIAN_PROBABILITY;
+             *settings++ = SEQ_CHANNEL_SETTING_MULT;
+         }
+         else
+            *settings++ = SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE_CV_RANGES;
+
+         *settings++ = SEQ_CHANNEL_SETTING_OCTAVE;
+         *settings++ = SEQ_CHANNEL_SETTING_ROOT;
+         // aux output:
+         *settings++ = SEQ_CHANNEL_SETTING_MODE;
+
+         switch (get_aux_mode()) {
+            case GATE_OUT:
+              *settings++ = SEQ_CHANNEL_SETTING_PULSEWIDTH;
+            break;
+            case COPY:
+              *settings++ = SEQ_CHANNEL_SETTING_OCTAVE_AUX;
+            break;
+            case ENV_AD:
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_PULSEWIDTH;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_MAX_LOOPS;
+            break;
+            case ENV_ADR:
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_PULSEWIDTH;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_SUSTAIN_LEVEL;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_RELEASE_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_RELEASE_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_MAX_LOOPS;
+            break;
+            case ENV_ADSR:
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_SHAPE;
+              *settings++ = SEQ_CHANNEL_SETTING_PULSEWIDTH;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_SUSTAIN_LEVEL;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_RELEASE_DURATION;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_RELEASE_SHAPE;
+            break;
+            default:
+            break;
+         }
+
+         if (get_playmode() < PM_SH1) {
+           *settings++ = SEQ_CHANNEL_SETTING_RESET;
+           *settings++ = SEQ_CHANNEL_SETTING_CLOCK;
+         }
+      }
+      break;
+
+      case CV_MAPPING: {
+
+         *settings++ = SEQ_CHANNEL_SETTING_TRANSPOSE_CV_SOURCE;  // = transpose SCALE
+         *settings++ = SEQ_CHANNEL_SETTING_SCALE_MASK_CV_SOURCE; // = rotate mask
+         *settings++ = SEQ_CHANNEL_SETTING_SEQ_CV_SOURCE; // sequence #
+
+         switch (get_sequence()) {
+
+            case 0:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK1;
+            break;
+            case 1:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK2;
+            break;
+            case 2:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK3;
+            break;
+            case 3:
+              *settings++ = SEQ_CHANNEL_SETTING_MASK4;
+            break;
+            default:
+            break;
+          }
+
+         *settings++ = SEQ_CHANNEL_SETTING_LENGTH_CV_SOURCE; // = playmode
+
+         if (get_playmode() < PM_SH1) {
+
+            if (get_playmode() == PM_ARP) {
+               *settings++ = SEQ_CHANNEL_SETTING_SEQUENCE_ARP_DIRECTION_CV_SOURCE;
+               *settings++ = SEQ_CHANNEL_SETTING_SEQUENCE_ARP_RANGE_CV_SOURCE;
+            }
+            else *settings++ = SEQ_CHANNEL_SETTING_DIRECTION_CV_SOURCE; // = directions
+
+            if (get_playmode() != PM_ARP && get_direction() == BROWNIAN)
+               *settings++ = SEQ_CHANNEL_SETTING_BROWNIAN_CV_SOURCE;
+
+            *settings++ = SEQ_CHANNEL_SETTING_MULT_CV_SOURCE;
+
+         }
+         else
+            *settings++ = SEQ_CHANNEL_SETTING_DUMMY; // = range
+
+         *settings++ = SEQ_CHANNEL_SETTING_OCTAVE_CV_SOURCE;
+         *settings++ = SEQ_CHANNEL_SETTING_ROOT_CV_SOURCE;
+         *settings++ = SEQ_CHANNEL_SETTING_DUMMY; // = mode
+
+         switch (get_aux_mode()) {
+
+            case GATE_OUT:
+              *settings++ = SEQ_CHANNEL_SETTING_PULSEWIDTH_CV_SOURCE;
+            break;
+            case COPY:
+              *settings++ = SEQ_CHANNEL_SETTING_OCTAVE_AUX_CV_SOURCE;
+            break;
+            case ENV_AD:
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_LOOPS_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_RESET_BEHAVIOUR;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_FALLING_GATE_BEHAVIOUR;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_RELEASE_RESET_BEHAVIOUR;
+            break;
+            case ENV_ADR:
+            case ENV_ADSR:
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_SUSTAIN_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_RELEASE_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_LOOPS_CV_SOURCE;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_RESET_BEHAVIOUR;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_ATTACK_FALLING_GATE_BEHAVIOUR;
+              *settings++ = SEQ_CHANNEL_SETTING_ENV_DECAY_RELEASE_RESET_BEHAVIOUR;
+            break;
+            default:
+            break;
+         }
+
+         if (get_playmode() < PM_SH1) {
+           *settings++ =  SEQ_CHANNEL_SETTING_TRIGGER_DELAY; //
+           *settings++ =  SEQ_CHANNEL_SETTING_CLOCK; // = reset source
+         }
+
+         *settings++ = SEQ_CHANNEL_SETTING_DUMMY; // = mode
+         *settings++ = SEQ_CHANNEL_SETTING_DUMMY; // = mode
+         *settings++ = SEQ_CHANNEL_SETTING_DUMMY; // = mode
+         *settings++ = SEQ_CHANNEL_SETTING_DUMMY; // = mode
+
+      }
+      break;
+      default:
+      break;
+   }
+   num_enabled_settings_ = settings - enabled_settings_;
+  }
+
+  template <DAC_CHANNEL dacChannel>
+  void update_main_channel() {
+    int32_t _output = OC::DAC::pitch_to_scaled_voltage_dac(dacChannel, get_step_pitch(), 0, OC::DAC::get_voltage_scaling(dacChannel));
+    OC::DAC::set<dacChannel>(_output);
+
+  }
+
+  template <DAC_CHANNEL dacChannel>
+  void update_aux_channel()
+  {
+
+      int8_t _mode = get_aux_mode();
+      uint32_t _output = 0;
+
+      switch (_mode) {
+
+        case GATE_OUT: // gate
+          #ifdef BUCHLA_4U
+          _output = (get_step_gate() == ON) ? OC::DAC::get_octave_offset(dacChannel, OCTAVES - OC::DAC::kOctaveZero - 0x2) : OC::DAC::get_zero_offset(dacChannel);
+          #else
+          _output = (get_step_gate() == ON) ? OC::DAC::get_octave_offset(dacChannel, OCTAVES - OC::DAC::kOctaveZero - 0x1) : OC::DAC::get_zero_offset(dacChannel);
+          #endif
+        break;
+        case COPY: // copy
+          _output = OC::DAC::pitch_to_scaled_voltage_dac(dacChannel, get_step_pitch_aux(), 0, OC::DAC::get_voltage_scaling(dacChannel));
+        break;
+        // code to process envelopes here
+        case  ENV_AD:
+        case ENV_ADR:
+        case ENV_ADSR:
+          env_gate_state_ = 0;
+          env_gate_raised_ = (get_step_gate() == ON);
+          if (env_gate_raised_ && !prev_gate_raised_)
+             env_gate_state_ |= peaks::CONTROL_GATE_RISING;
+          if (env_gate_raised_)
+             env_gate_state_ |= peaks::CONTROL_GATE;
+          else if (prev_gate_raised_)
+            env_gate_state_ |= peaks::CONTROL_GATE_FALLING;
+          prev_gate_raised_ = env_gate_raised_;
+          _output = OC::DAC::get_zero_offset(dacChannel) + env_.ProcessSingleSample(env_gate_state_);
+        break;
+        default:
+        break;
+      }
+      OC::DAC::set<dacChannel>(_output);
+  }
+
+  void RenderScreensaver() const;
+
+private:
+
+  bool channel_id_;
+  bool octave_toggle_;
+  bool wait_for_EoS_;
+  bool note_repeat_;
+  bool sequence_EoS_;
+  uint8_t menu_page_;
+  uint16_t _sync_cnt;
+  bool force_update_;
+  bool force_scale_update_;
+  uint8_t clk_src_;
+  bool prev_reset_state_;
+  bool reset_pending_;
+  uint32_t subticks_;
+  uint32_t tickjitter_;
+  int32_t clk_cnt_;
+  int32_t prev_slot_;
+  int16_t div_cnt_;
+  uint32_t ext_frequency_in_ticks_;
+  uint32_t channel_frequency_in_ticks_;
+  uint32_t pulse_width_in_ticks_;
+  uint16_t gate_state_;
+  uint8_t prev_gate_raised_;
+  uint8_t env_gate_state_;
+  uint8_t env_gate_raised_;
+  uint16_t step_state_;
+  int32_t step_pitch_;
+  int32_t step_pitch_aux_;
+  uint8_t prev_multiplier_;
+  uint8_t prev_pulsewidth_;
+  uint8_t display_num_sequence_;
+  uint16_t display_mask_;
+  int8_t active_sequence_;
+  int8_t sequence_manual_;
+  int8_t active_sequence_length_;
+  int32_t sequence_cnt_;
+  int8_t sequence_advance_state_;
+  int8_t sequence_change_pending_;
+  int8_t pendulum_fwd_;
+  int last_scale_;
+  uint16_t last_scale_mask_;
+  uint8_t prev_input_range_;
+  uint8_t prev_playmode_;
+  bool pending_sync_;
+
+  util::TriggerDelay<OC::kMaxTriggerDelayTicks> trigger_delay_;
+  util::Arpeggiator arpeggiator_;
+
+  int num_enabled_settings_;
+  SEQ_ChannelSetting enabled_settings_[SEQ_CHANNEL_SETTING_LAST];
+  braids::Quantizer quantizer_;
+  OC::Input_Map input_map_;
+  OC::DigitalInputDisplay clock_display_;
+  peaks::MultistageEnvelope env_;
+
+};
+
+const char* const SEQ_CHANNEL_TRIGGER_sources[] = {
+  "TR1", "TR3", " - "
+};
+
+const char* const reset_trigger_sources[] = {
+  "RST2", "RST4", " - ", "=HI2", "=LO2", "=HI4", "=LO4"
+};
+
+const char* const display_multipliers[] = {
+  "/64", "/63", "/62", "/49", "/48", "/47", "/33", "/32", "/31", "/17", "/16", "/15", "/8", "/7", "/6", "/5", "/4", "/3", "/2", "-", "x2", "x3", "x4", "x5", "x6", "x7", "x8"
+};
+
+const char* const modes[] = {
+  "gate", "copy", "AD", "ADR", "ADSR",
+};
+
+const char* const cv_ranges[] = {
+  " 5V", "10V"
+};
+
+const char* const arp_directions[] = {
+  "up", "down", "u/d", "rnd"
+};
+
+const char* const arp_range[] = {
+  "1", "2", "3", "4"
+};
+
+SETTINGS_DECLARE(SEQ_Channel, SEQ_CHANNEL_SETTING_LAST) {
+
+  { 0, 0, 4, "aux. mode", modes, settings::STORAGE_TYPE_U4 },
+  { SEQ_CHANNEL_TRIGGER_TR1, 0, SEQ_CHANNEL_TRIGGER_NONE, "clock src", SEQ_CHANNEL_TRIGGER_sources, settings::STORAGE_TYPE_U4 },
+  { 0, 0, OC::kNumDelayTimes - 1, "trigger delay", OC::Strings::trigger_delay_times, settings::STORAGE_TYPE_U8 },
+  { 2, 0, SEQ_CHANNEL_TRIGGER_LAST - 1, "reset/mute", reset_trigger_sources, settings::STORAGE_TYPE_U8 },
+  { MULT_BY_ONE, 0, MULT_MAX, "mult/div", display_multipliers, settings::STORAGE_TYPE_U8 },
+  { 25, 0, PULSEW_MAX, "--> pw", NULL, settings::STORAGE_TYPE_U8 },
+  //
+  { OC::Scales::SCALE_SEMI, 0, OC::Scales::NUM_SCALES - 1, "scale", OC::scale_names_short, settings::STORAGE_TYPE_U8 },
+  { 0, -5, 5, "octave", NULL, settings::STORAGE_TYPE_I8 }, // octave
+  { 0, 0, 11, "root", OC::Strings::note_names_unpadded, settings::STORAGE_TYPE_U8 },
+  { 0, -5, 5, "--> aux +/-", NULL, settings::STORAGE_TYPE_I8 }, // aux octave
+  { 65535, 1, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 }, // mask
+  // seq
+  { 65535, 0, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 }, // seq 1
+  { 65535, 0, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 }, // seq 2
+  { 65535, 0, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 }, // seq 3
+  { 65535, 0, 65535, "--> edit", NULL, settings::STORAGE_TYPE_U16 }, // seq 4
+  { OC::Patterns::PATTERN_USER_0_1, 0, OC::Patterns::PATTERN_USER_LAST-1, "sequence #", OC::pattern_names_short, settings::STORAGE_TYPE_U8 },
+  { OC::Patterns::kMax, OC::Patterns::kMin, OC::Patterns::kMax, "sequence length", NULL, settings::STORAGE_TYPE_U8 }, // seq 1
+  { OC::Patterns::kMax, OC::Patterns::kMin, OC::Patterns::kMax, "sequence length", NULL, settings::STORAGE_TYPE_U8 }, // seq 2
+  { OC::Patterns::kMax, OC::Patterns::kMin, OC::Patterns::kMax, "sequence length", NULL, settings::STORAGE_TYPE_U8 }, // seq 3
+  { OC::Patterns::kMax, OC::Patterns::kMin, OC::Patterns::kMax, "sequence length", NULL, settings::STORAGE_TYPE_U8 }, // seq 4
+  { 0, 0, PM_LAST - 1, "playmode", OC::Strings::seq_playmodes, settings::STORAGE_TYPE_U8 },
+  { 0, 0, SEQ_DIRECTIONS_LAST - 1, "direction", OC::Strings::seq_directions, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 1, "CV adr. range", cv_ranges, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 3, "direction", arp_directions, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 3, "arp.range", arp_range, settings::STORAGE_TYPE_U8 },
+  { 64, 0, 255, "-->brown prob", NULL, settings::STORAGE_TYPE_U8 },
+  // cv sources
+  { 0, 0, 4, "mult/div CV ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "transpose   ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "--> pw      ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "octave  +/- ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "root    +/- ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "--> aux +/- ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "sequence #  ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "mask rotate ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "direction   ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "arp.range   ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "direction   ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "-->brwn.prb ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "seq.length  ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "att dur  ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "dec dur  ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "sus lvl  ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "rel dur  ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U4 },
+  { 0, 0, 4, "env loops ->", OC::Strings::cv_input_names_none, settings::STORAGE_TYPE_U8 },
+  { 0, 0, 1, "-", NULL, settings::STORAGE_TYPE_U4 }, // DUMMY, use to store update behaviour
+  // envelope parameters
+  { 128, 0, 255, "--> att dur", NULL, settings::STORAGE_TYPE_U8 },
+  { peaks::ENV_SHAPE_QUARTIC, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "--> att shape", OC::Strings::envelope_shapes, settings::STORAGE_TYPE_U16 },
+  { 128, 0, 255, "--> dec dur", NULL, settings::STORAGE_TYPE_U8 },
+  { peaks::ENV_SHAPE_EXPONENTIAL, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "--> dec shape", OC::Strings::envelope_shapes, settings::STORAGE_TYPE_U16 },
+  { 128, 0, 255, "--> sus lvl", NULL, settings::STORAGE_TYPE_U16 },
+  { 128, 0, 255, "--> rel dur", NULL, settings::STORAGE_TYPE_U8 },
+  { peaks::ENV_SHAPE_EXPONENTIAL, peaks::ENV_SHAPE_LINEAR, peaks::ENV_SHAPE_LAST - 1, "--> rel shape", OC::Strings::envelope_shapes, settings::STORAGE_TYPE_U16 },
+  {1, 1, 127, "--> loops", NULL, settings::STORAGE_TYPE_U8 },
+  { peaks::RESET_BEHAVIOUR_NULL, peaks::RESET_BEHAVIOUR_NULL, peaks::RESET_BEHAVIOUR_LAST - 1, "att reset", OC::Strings::reset_behaviours, settings::STORAGE_TYPE_U8 },
+  { peaks::FALLING_GATE_BEHAVIOUR_IGNORE, peaks::FALLING_GATE_BEHAVIOUR_IGNORE, peaks::FALLING_GATE_BEHAVIOUR_LAST - 1, "att fall gt", OC::Strings::falling_gate_behaviours, settings::STORAGE_TYPE_U8 },
+  { peaks::RESET_BEHAVIOUR_SEGMENT_PHASE, peaks::RESET_BEHAVIOUR_NULL, peaks::RESET_BEHAVIOUR_LAST - 1, "dec/rel reset", OC::Strings::reset_behaviours, settings::STORAGE_TYPE_U8 },
+};
+
+class SEQ_State {
+public:
+  void Init() {
+    selected_channel = 0;
+    cursor.Init(SEQ_CHANNEL_SETTING_MODE, SEQ_CHANNEL_SETTING_LAST - 1);
+    pattern_editor.Init();
+    scale_editor.Init(false);
+  }
+
+  inline bool editing() const {
+    return cursor.editing();
+  }
+
+  inline int cursor_pos() const {
+    return cursor.cursor_pos();
+  }
+
+  int selected_channel;
+  menu::ScreenCursor<menu::kScreenLines> cursor;
+  menu::ScreenCursor<menu::kScreenLines> cursor_state;
+  OC::PatternEditor<SEQ_Channel> pattern_editor;
+  OC::ScaleEditor<SEQ_Channel> scale_editor;
+};
+
+SEQ_State seq_state;
+SEQ_Channel seq_channel[NUM_CHANNELS];
+
+void SEQ_init() {
+
+  ext_frequency[SEQ_CHANNEL_TRIGGER_TR1]  = 0xFFFFFFFF;
+  ext_frequency[SEQ_CHANNEL_TRIGGER_TR2]  = 0xFFFFFFFF;
+  ext_frequency[SEQ_CHANNEL_TRIGGER_NONE] = 0xFFFFFFFF;
+
+  seq_state.Init();
+  for (size_t i = 0; i < NUM_CHANNELS; ++i)
+    seq_channel[i].Init(static_cast<SEQ_ChannelTriggerSource>(SEQ_CHANNEL_TRIGGER_TR1), i);
+  seq_state.cursor.AdjustEnd(seq_channel[0].num_enabled_settings() - 1);
+}
+
+size_t SEQ_storageSize() {
+  return NUM_CHANNELS * SEQ_Channel::storageSize();
+}
+
+size_t SEQ_save(void *storage) {
+
+  size_t used = 0;
+  for (size_t i = 0; i < NUM_CHANNELS; ++i) {
+    used += seq_channel[i].Save(static_cast<char*>(storage) + used);
+  }
+  return used;
+}
+
+size_t SEQ_restore(const void *storage) {
+
+  size_t used = 0;
+
+  for (size_t i = 0; i < NUM_CHANNELS; ++i) {
+    used += seq_channel[i].Restore(static_cast<const char*>(storage) + used);
+    // update display
+    seq_channel[i].pattern_changed(seq_channel[i].get_mask(seq_channel[i].get_sequence()), true);
+    seq_channel[i].set_display_num_sequence(seq_channel[i].get_sequence());
+    seq_channel[i].update_enabled_settings(i);
+    seq_channel[i].set_EoS_update();
+  }
+  seq_state.cursor.AdjustEnd(seq_channel[0].num_enabled_settings() - 1);
+  return used;
+}
+
+void SEQ_handleAppEvent(OC::AppEvent event) {
+  switch (event) {
+    case OC::APP_EVENT_RESUME:
+        seq_state.cursor.set_editing(false);
+        seq_state.pattern_editor.Close();
+        seq_state.scale_editor.Close();
+    break;
+    case OC::APP_EVENT_SUSPEND:
+    case OC::APP_EVENT_SCREENSAVER_ON:
+    case OC::APP_EVENT_SCREENSAVER_OFF:
+    {
+       SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+       selected.set_menu_page(PARAMETERS);
+       selected.update_enabled_settings(seq_state.selected_channel);
+    }
+    break;
+  }
+}
+
+void SEQ_loop() {
+}
+
+void SEQ_isr() {
+
+  ticks_src1++; // src #1 ticks
+  ticks_src2++; // src #2 ticks
+  copy_timeout++;
+
+  uint32_t triggers = OC::DigitalInputs::clocked();
+
+  if (triggers & (1 << OC::DIGITAL_INPUT_1)) {
+    ext_frequency[SEQ_CHANNEL_TRIGGER_TR1] = ticks_src1;
+    ticks_src1 = 0x0;
+  }
+  if (triggers & (1 << OC::DIGITAL_INPUT_3)) {
+    ext_frequency[SEQ_CHANNEL_TRIGGER_TR2] = ticks_src2;
+    ticks_src2 = 0x0;
+  }
+
+  // update sequencer channels 1, 2:
+  seq_channel[0].Update(triggers, DAC_CHANNEL_A);
+  seq_channel[1].Update(triggers, DAC_CHANNEL_B);
+  // update DAC channels A, B:
+  seq_channel[0].update_main_channel<DAC_CHANNEL_A>();
+  seq_channel[1].update_main_channel<DAC_CHANNEL_B>();
+  // update DAC channels C, D:
+  seq_channel[0].update_aux_channel<DAC_CHANNEL_C>();
+  seq_channel[1].update_aux_channel<DAC_CHANNEL_D>();
+}
+
+void SEQ_handleButtonEvent(const UI::Event &event) {
+
+  if (UI::EVENT_BUTTON_LONG_PRESS == event.type) {
+     switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+         SEQ_upButtonLong();
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        SEQ_downButtonLong();
+        break;
+       case OC::CONTROL_BUTTON_L:
+        if (!(seq_state.pattern_editor.active()))
+          SEQ_leftButtonLong();
+        break;
+      default:
+        break;
+     }
+  }
+
+  if (seq_state.pattern_editor.active()) {
+    seq_state.pattern_editor.HandleButtonEvent(event);
+    return;
+  }
+  else if (seq_state.scale_editor.active()) {
+    seq_state.scale_editor.HandleButtonEvent(event);
+    return;
+  }
+
+  if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        SEQ_upButton();
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        SEQ_downButton();
+        break;
+      case OC::CONTROL_BUTTON_L:
+        SEQ_leftButton();
+        break;
+      case OC::CONTROL_BUTTON_R:
+        SEQ_rightButton();
+        break;
+    }
+  }
+}
+
+void SEQ_handleEncoderEvent(const UI::Event &event) {
+
+  if (seq_state.pattern_editor.active()) {
+    seq_state.pattern_editor.HandleEncoderEvent(event);
+    return;
+  }
+  else if (seq_state.scale_editor.active()) {
+    seq_state.scale_editor.HandleEncoderEvent(event);
+    return;
+  }
+
+  if (OC::CONTROL_ENCODER_L == event.control) {
+
+    int selected_channel = seq_state.selected_channel + event.value;
+    CONSTRAIN(selected_channel, 0, NUM_CHANNELS-1);
+    seq_state.selected_channel = selected_channel;
+
+    SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+
+    selected.update_enabled_settings(seq_state.selected_channel);
+    seq_state.cursor.Init(SEQ_CHANNEL_SETTING_MODE, 0);
+    seq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+
+  } else if (OC::CONTROL_ENCODER_R == event.control) {
+
+       SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+
+       if (seq_state.editing()) {
+
+          SEQ_ChannelSetting setting = selected.enabled_setting_at(seq_state.cursor_pos());
+
+          if (SEQ_CHANNEL_SETTING_SCALE_MASK != setting || SEQ_CHANNEL_SETTING_MASK1 != setting || SEQ_CHANNEL_SETTING_MASK2 != setting || SEQ_CHANNEL_SETTING_MASK3 != setting || SEQ_CHANNEL_SETTING_MASK4 != setting) {
+
+            if (selected.change_value(setting, event.value))
+             selected.force_update();
+
+            switch (setting) {
+
+              case SEQ_CHANNEL_SETTING_SEQUENCE:
+              {
+                uint8_t seq = selected.get_sequence();
+                uint8_t playmode = selected.get_playmode();
+                // details: update mask/sequence, depending on mode.
+                if (!playmode || playmode >= PM_CV1 || selected.get_current_sequence() == seq || selected.update_timeout()) {
+                  selected.set_display_num_sequence(seq);
+                  selected.pattern_changed(selected.get_mask(seq), true);
+                }
+              }
+              break;
+              case SEQ_CHANNEL_SETTING_MODE:
+              case SEQ_CHANNEL_SETTING_SEQUENCE_PLAYMODE:
+              case SEQ_CHANNEL_SETTING_SEQUENCE_DIRECTION:
+                 selected.update_enabled_settings(seq_state.selected_channel);
+                 seq_state.cursor.AdjustEnd(selected.num_enabled_settings() - 1);
+              break;
+             default:
+              break;
+            }
+        }
+      } else {
+      seq_state.cursor.Scroll(event.value);
+    }
+  }
+}
+
+void SEQ_upButton() {
+
+  SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+
+  if (selected.get_menu_page() == PARAMETERS) {
+
+    if (selected.octave_toggle())
+      selected.change_value(SEQ_CHANNEL_SETTING_OCTAVE, 1);
+    else
+      selected.change_value(SEQ_CHANNEL_SETTING_OCTAVE, -1);
+  }
+  else  {
+    selected.set_menu_page(PARAMETERS);
+    selected.update_enabled_settings(seq_state.selected_channel);
+    seq_state.cursor.set_editing(false);
+  }
+}
+
+void SEQ_downButton() {
+
+  SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+
+  if (!seq_state.pattern_editor.active() && !seq_state.scale_editor.active()) {
+
+      uint8_t _menu_page = selected.get_menu_page();
+
+      switch (_menu_page) {
+
+        case PARAMETERS:
+        _menu_page = CV_MAPPING;
+        break;
+        default:
+        _menu_page = PARAMETERS;
+        break;
+
+      }
+
+      selected.set_menu_page(_menu_page);
+      selected.update_enabled_settings(seq_state.selected_channel);
+      seq_state.cursor.set_editing(false);
+  }
+  /*
+  SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+  if (selected.get_menu_page() == PARAMETERS)
+    selected.change_value(SEQ_CHANNEL_SETTING_OCTAVE, -1);
+  else {
+    selected.set_menu_page(PARAMETERS);
+    selected.update_enabled_settings(seq_state.selected_channel);
+    seq_state.cursor.set_editing(false);
+  }
+  */
+}
+
+void SEQ_rightButton() {
+
+  SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+
+  switch (selected.enabled_setting_at(seq_state.cursor_pos())) {
+
+    case SEQ_CHANNEL_SETTING_SCALE:
+      seq_state.cursor.toggle_editing();
+      selected.update_scale(true);
+    break;
+    case SEQ_CHANNEL_SETTING_SCALE_MASK:
+    {
+     int scale = selected.get_scale(DUMMY);
+     if (OC::Scales::SCALE_NONE != scale) {
+          seq_state.scale_editor.Edit(&selected, scale);
+        }
+    }
+    break;
+    case SEQ_CHANNEL_SETTING_MASK1:
+    case SEQ_CHANNEL_SETTING_MASK2:
+    case SEQ_CHANNEL_SETTING_MASK3:
+    case SEQ_CHANNEL_SETTING_MASK4:
+    {
+      int pattern = selected.get_sequence();
+      if (OC::Patterns::PATTERN_NONE != pattern) {
+        seq_state.pattern_editor.Edit(&selected, pattern);
+      }
+    }
+    break;
+    case SEQ_CHANNEL_SETTING_DUMMY:
+      selected.set_menu_page(PARAMETERS);
+      selected.update_enabled_settings(seq_state.selected_channel);
+    break;
+    default:
+     seq_state.cursor.toggle_editing();
+    break;
+  }
+}
+
+void SEQ_leftButton() {
+  // sync:
+  for (int i = 0; i < NUM_CHANNELS; ++i)
+        seq_channel[i].sync();
+}
+
+void SEQ_leftButtonLong() {
+  // copy scale
+  if (!seq_state.pattern_editor.active() && !seq_state.scale_editor.active()) {
+
+      uint8_t this_channel, the_other_channel, scale;
+      uint16_t mask;
+
+      this_channel = seq_state.selected_channel;
+      scale = seq_channel[this_channel].get_scale(DUMMY);
+      mask = seq_channel[this_channel].get_rotated_scale_mask();
+
+      the_other_channel = (~this_channel) & 1u;
+      seq_channel[the_other_channel].set_scale(scale);
+      seq_channel[the_other_channel].update_scale_mask(mask, DUMMY);
+      seq_channel[the_other_channel].update_scale(true);
+  }
+}
+
+void SEQ_upButtonLong() {
+  // screensaver short cut (happens elsewhere)
+}
+
+void SEQ_downButtonLong() {
+  // clear CV mappings:
+  SEQ_Channel &selected = seq_channel[seq_state.selected_channel];
+
+  if (selected.get_menu_page() == CV_MAPPING) {
+    selected.clear_CV_mapping();
+    seq_state.cursor.set_editing(false);
+  }
+  else { // toggle update behaviour:
+    seq_channel[0x0].toggle_EoS();
+    seq_channel[0x1].toggle_EoS();
+  }
+}
+
+void SEQ_menu() {
+
+  menu::DualTitleBar::Draw();
+
+  for (int i = 0, x = 0; i < NUM_CHANNELS; ++i, x += 21) {
+
+    const SEQ_Channel &channel = seq_channel[i];
+    menu::DualTitleBar::SetColumn(i);
+
+    // draw gate/step indicator
+    uint8_t gate = 1;
+    if (channel.get_step_gate() == ON)
+      gate += 14;
+    else if (channel.get_step_state() == ON)
+      gate += 10;
+    menu::DualTitleBar::DrawGateIndicator(i, gate);
+
+    graphics.movePrintPos(5, 0);
+    // channel id:
+    graphics.print("#");
+    graphics.print((char)('A' + i));
+    // sequence id:
+    graphics.print("/");
+    graphics.print(1 + channel.get_display_num_sequence());
+    // octave:
+    graphics.movePrintPos(22, 0);
+    if (channel.poke_octave_toggle())
+      graphics.print("+");
+  }
+
+  const SEQ_Channel &channel = seq_channel[seq_state.selected_channel];
+
+  menu::DualTitleBar::Selected(seq_state.selected_channel);
+
+  menu::SettingsList<menu::kScreenLines, 0, menu::kDefaultValueX> settings_list(seq_state.cursor);
+
+  menu::SettingsListItem list_item;
+
+   while (settings_list.available()) {
+    const int setting =
+        channel.enabled_setting_at(settings_list.Next(list_item));
+    const int value = channel.get_value(setting);
+    const settings::value_attr &attr = SEQ_Channel::value_attr(setting);
+
+    switch (setting) {
+
+      case SEQ_CHANNEL_SETTING_SCALE:
+        list_item.SetPrintPos();
+        if (list_item.editing) {
+          menu::DrawEditIcon(6, list_item.y, value, attr);
+          graphics.movePrintPos(6, 0);
+        }
+        graphics.print(OC::scale_names[value]);
+        list_item.DrawCustom();
+        break;
+      case SEQ_CHANNEL_SETTING_SCALE_MASK:
+       menu::DrawMask<false, 16, 8, 1>(menu::kDisplayWidth, list_item.y, channel.get_rotated_scale_mask(), OC::Scales::GetScale(channel.get_scale(DUMMY)).num_notes);
+       list_item.DrawNoValue<false>(value, attr);
+      break;
+      case SEQ_CHANNEL_SETTING_MASK1:
+      case SEQ_CHANNEL_SETTING_MASK2:
+      case SEQ_CHANNEL_SETTING_MASK3:
+      case SEQ_CHANNEL_SETTING_MASK4:
+      {
+        int clock_indicator = channel.get_clock_cnt();
+        if (channel.get_playmode() == PM_ARP)
+          clock_indicator = 0xFF;
+        menu::DrawMask<false, 16, 8, 1>(menu::kDisplayWidth, list_item.y, channel.get_display_mask(), channel.get_display_length(), clock_indicator);
+        list_item.DrawNoValue<false>(value, attr);
+      }
+      break;
+      case SEQ_CHANNEL_SETTING_PULSEWIDTH:
+        if (channel.get_aux_mode() < ENV_AD) {
+          list_item.Draw_PW_Value(value, attr);
+        } else {
+          list_item.Draw_PW_Value_Char(value, attr, "--> sus dur");
+        }
+      break;
+      case SEQ_CHANNEL_SETTING_DUMMY:
+        list_item.DrawNoValue<false>(value, attr);
+      break;
+      default:
+        list_item.DrawDefault(value, attr);
+      break;
+    }
+  }
+
+  if (seq_state.pattern_editor.active())
+    seq_state.pattern_editor.Draw();
+  else if (seq_state.scale_editor.active())
+    seq_state.scale_editor.Draw();
+}
+
+
+void SEQ_Channel::RenderScreensaver() const {
+
+      uint8_t seq_id = channel_id_;
+      uint8_t clock_x_pos = seq_channel[seq_id].get_clock_cnt();
+      int32_t _dac_value = seq_channel[seq_id].get_step_pitch();
+      int32_t _dac_overflow = 0, _dac_overflow2 = 0;
+
+      // reposition ARP:
+      if (seq_channel[seq_id].get_playmode() == PM_ARP)
+        clock_x_pos = 0x6 + (seq_id << 2);
+
+      clock_x_pos = (seq_id << 6) + (clock_x_pos << 2);
+
+      // clock/step indicator:
+      if(seq_channel[seq_id].step_state_ == OFF) {
+        graphics.drawRect(clock_x_pos, 63, 5, 2);
+        _dac_value = 0;
+      }
+      else
+        graphics.drawRect(clock_x_pos, 60, 5, 5);
+
+      // separate windows ...
+      graphics.drawVLine(64, 0, 68);
+
+      // display pitch values as squares/frames:
+      if (_dac_value < 0) {
+        // display negative values as frame (though they're not negative...)
+        _dac_value = (_dac_value - (_dac_value << 1 )) >> 6;
+        _dac_overflow = _dac_value - 40;
+        _dac_overflow2 = _dac_overflow - 40;
+
+        CONSTRAIN(_dac_value, 1, 40);
+
+        int8_t x = 2 + clock_x_pos - (_dac_value >> 1);
+        int8_t x_size = 0;
+
+        // limit size of frame to window size
+        if (seq_id && x < 64) {
+          x_size = 64 - x;
+          x = 64;
+        }
+        else if (!seq_id && (x + _dac_value > 63))
+          x_size =  (x + _dac_value) - 64;
+        // draw
+        graphics.drawFrame(x, 30 - (_dac_value >> 1), _dac_value - x_size, _dac_value);
+
+        if (_dac_overflow > 0) {
+
+            CONSTRAIN(_dac_overflow, 1, 40);
+
+            x = 2 + clock_x_pos - (_dac_overflow >> 1);
+
+            if (seq_id && x < 64) {
+              x_size = 64 - x;
+              x = 64;
+            }
+            else if (!seq_id && (x + _dac_overflow > 63))
+              x_size =  (x + _dac_overflow) - 64;
+
+            graphics.drawRect(x, 30 - (_dac_overflow >> 1), _dac_overflow - x_size, _dac_overflow);
+         }
+
+         if (_dac_overflow2 > 0) {
+
+            CONSTRAIN(_dac_overflow2, 1, 40);
+
+            x = 2 + clock_x_pos - (_dac_overflow2 >> 1);
+
+            if (seq_id && x < 64) {
+              x_size = 64 - x;
+              x = 64;
+            }
+            else if (!seq_id && (x + _dac_overflow2 > 63))
+              x_size =  (x + _dac_overflow2) - 64;
+
+            graphics.clearRect(x, 30 - (_dac_overflow2 >> 1), _dac_overflow2 - x_size, _dac_overflow2);
+         }
+      }
+      else {
+      // positive output as rectangle
+        _dac_value = (_dac_value  >> 6);
+        _dac_overflow = _dac_value - 40;
+        _dac_overflow2 = _dac_overflow - 40;
+
+        CONSTRAIN(_dac_value, 1, 40);
+
+        int8_t x = 2 + clock_x_pos - (_dac_value >> 1);
+        int8_t x_size = 0;
+        // limit size of rectangle to window size
+        if (seq_id && x < 64) {
+          x_size = 64 - x;
+          x = 64;
+        }
+        else if (!seq_id && (x + _dac_value > 63))
+          x_size = (x + _dac_value) - 64;
+        // draw
+        graphics.drawRect(x, 30 - (_dac_value >> 1), _dac_value - x_size, _dac_value);
+
+        if (_dac_overflow > 0) {
+
+          CONSTRAIN(_dac_overflow, 1, 40);
+
+          x = 2 + clock_x_pos - (_dac_overflow >> 1);
+
+          if (seq_id && x < 64) {
+            x_size = 64 - x;
+            x = 64;
+          }
+          else if (!seq_id && (x + _dac_overflow > 63))
+             x_size = (x + _dac_overflow) - 64;
+
+          graphics.clearRect(x, 30 - (_dac_overflow >> 1), _dac_overflow - x_size, _dac_overflow);
+        }
+
+        if (_dac_overflow2 > 0) {
+
+          CONSTRAIN(_dac_overflow2, 1, 40);
+
+          x = 2 + clock_x_pos - (_dac_overflow2 >> 1);
+
+          if (seq_id && x < 64) {
+            x_size = 64 - x;
+            x = 64;
+          }
+          else if (!seq_id && (x + _dac_overflow2 > 63))
+             x_size = (x + _dac_overflow2) - 64;
+
+          graphics.drawRect(x, 30 - (_dac_overflow2 >> 1), _dac_overflow2 - x_size, _dac_overflow2);
+        }
+    }
+}
+
+void SEQ_screensaver() {
+
+  seq_channel[0].RenderScreensaver();
+  seq_channel[1].RenderScreensaver();
+}
+

--- a/software/o_c_REV/OC_apps.h
+++ b/software/o_c_REV/OC_apps.h
@@ -24,6 +24,7 @@
 #define OC_APP_H_
 
 #include "UI/ui_events.h"
+#include "util/util_turing.h"
 #include "util/util_misc.h"
 
 namespace OC {

--- a/software/o_c_REV/OC_apps.ino
+++ b/software/o_c_REV/OC_apps.ino
@@ -42,6 +42,14 @@ OC::App available_apps[] = {
   #ifdef ENABLE_APP_METAQ
   DECLARE_APP('M','!', "Meta-Q", DQ),
   #endif
+
+  #ifdef ENABLE_APP_CHORDS
+  DECLARE_APP('A','C', "Acid Curds", CHORDS),
+  #endif
+  #ifdef ENABLE_APP_SEQUINS
+  DECLARE_APP('S','Q', "Sequins", SEQ),
+  #endif
+
   #ifdef ENABLE_APP_MIDI
   DECLARE_APP('M','I', "Captain MIDI", MIDI),
   #endif

--- a/software/o_c_REV/OC_apps.ino
+++ b/software/o_c_REV/OC_apps.ino
@@ -36,6 +36,12 @@
 
 OC::App available_apps[] = {
   DECLARE_APP('H','S', "Hemisphere", HEMISPHERE),
+  #ifdef ENABLE_APP_QUANTERMAIN
+  DECLARE_APP('Q','Q', "Quantermain", QQ),
+  #endif
+  #ifdef ENABLE_APP_METAQ
+  DECLARE_APP('M','!', "Meta-Q", DQ),
+  #endif
   #ifdef ENABLE_APP_MIDI
   DECLARE_APP('M','I', "Captain MIDI", MIDI),
   #endif

--- a/software/o_c_REV/OC_chords.cpp
+++ b/software/o_c_REV/OC_chords.cpp
@@ -1,0 +1,29 @@
+#include "OC_chords.h"
+#include "OC_chords_presets.h"
+
+namespace OC {
+
+    Chord user_chords[Chords::CHORDS_USER_LAST];
+
+    /*static*/
+    const int Chords::NUM_CHORD_PROGRESSIONS = 0x4;
+    const int Chords::NUM_CHORDS_TOTAL = OC::Chords::CHORDS_USER_LAST; // = 8
+    const int Chords::NUM_CHORDS_PROPERTIES = sizeof(Chord);
+    const int Chords::NUM_CHORDS = Chords::NUM_CHORDS_TOTAL / Chords::NUM_CHORD_PROGRESSIONS;
+
+    /*static*/
+    // 
+    void Chords::Init() {
+      for (size_t i = 0; i < OC::Chords::CHORDS_USER_LAST; ++i)
+        memcpy(&user_chords[i], &OC::chords[0], sizeof(Chord));
+    }
+
+    const Chord &Chords::GetChord(int index, int progression) {
+
+       uint8_t _index = index + progression * Chords::NUM_CHORDS;
+       if (_index < CHORDS_USER_LAST) 
+        return user_chords[_index];
+       else
+        return user_chords[0x0];
+    }
+} // namespace OC

--- a/software/o_c_REV/OC_chords.h
+++ b/software/o_c_REV/OC_chords.h
@@ -1,0 +1,105 @@
+#ifndef OC_CHORDS_H_
+#define OC_CHORDS_H_
+
+#include "OC_chords_presets.h"
+
+namespace OC {
+
+typedef OC::Chord Chord;
+
+class Chords {
+public:
+
+  static const int NUM_CHORDS_TOTAL;
+  static const int NUM_CHORDS;
+  static const int NUM_CHORDS_PROPERTIES;
+  static const int NUM_CHORD_PROGRESSIONS;
+
+  enum CHORD_SLOTS
+  {
+    CHORDS_USER_0_0,
+    CHORDS_USER_1_0,
+    CHORDS_USER_2_0,
+    CHORDS_USER_3_0,
+    CHORDS_USER_4_0,
+    CHORDS_USER_5_0,
+    CHORDS_USER_6_0,
+    CHORDS_USER_7_0,
+    CHORDS_USER_0_1,
+    CHORDS_USER_1_1,
+    CHORDS_USER_2_1,
+    CHORDS_USER_3_1,
+    CHORDS_USER_4_1,
+    CHORDS_USER_5_1,
+    CHORDS_USER_6_1,
+    CHORDS_USER_7_1,
+    CHORDS_USER_0_2,
+    CHORDS_USER_1_2,
+    CHORDS_USER_2_2,
+    CHORDS_USER_3_2,
+    CHORDS_USER_4_2,
+    CHORDS_USER_5_2,
+    CHORDS_USER_6_2,
+    CHORDS_USER_7_2,
+    CHORDS_USER_0_3,
+    CHORDS_USER_1_3,
+    CHORDS_USER_2_3,
+    CHORDS_USER_3_3,
+    CHORDS_USER_4_3,
+    CHORDS_USER_5_3,
+    CHORDS_USER_6_3,
+    CHORDS_USER_7_3,
+    CHORDS_USER_LAST
+  };
+
+  enum QUALITY 
+  {
+    CHORDS_FIFTH,
+    CHORDS_TRIAD,
+    CHORDS_SEVENTH,
+    CHORDS_SUSPENDED,
+    CHORDS_SUSPENDED_SEVENTH,
+    CHORDS_SIXTH,
+    CHORDS_ADDED_NINTH,
+    CHORDS_ADDED_ELEVENTH,
+    CHORDS_UNISONO,
+    CHORDS_QUALITY_LAST
+  };
+
+  enum CHORDS_TYPE 
+  {
+    CHORDS_TYPE_MONAD,
+    CHORDS_TYPE_DYAD,
+    CHORDS_TYPE_TRIAD,
+    CHORDS_TYPE_TETRAD,
+    CHORDS_TYPE_LAST
+  };
+
+  enum VOICING 
+  {
+    CHORDS_CLOSE,
+    CHORDS_DROP_1,
+    CHORDS_DROP_2,
+    CHORDS_DROP_3,
+    CHORDS_SPREAD,
+    CHORDS_VOICING_LAST
+  };
+
+  enum INVERSION
+  {
+    CHORDS_INVERSION_NONE,
+    CHORDS_INVERSION_FIRST,
+    CHORDS_INVERSION_SECOND,
+    CHORDS_INVERSION_THIRD,
+    CHORDS_INVERSION_LAST 
+  };
+  
+  static void Init();
+  static const Chord &GetChord(int index, int progression);
+};
+
+
+extern Chord user_chords[OC::Chords::CHORDS_USER_LAST];
+};
+
+#endif // OC_CHORDS_H_

--- a/software/o_c_REV/OC_chords_edit.h
+++ b/software/o_c_REV/OC_chords_edit.h
@@ -1,0 +1,450 @@
+// Copyright (c)  2015, 2016, 2017 Patrick Dowling, Max Stadler, Tim Churches
+//
+// Author of original O+C firmware: Max Stadler (mxmlnstdlr@gmail.com)
+// Author of app scaffolding: Patrick Dowling (pld@gurkenkiste.com)
+// Modified for bouncing balls: Tim Churches (tim.churches@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef OC_CHORDS_EDIT_H_
+#define OC_CHORDS_EDIT_H_
+
+#include "OC_bitmaps.h"
+#include "OC_chords.h"
+#include "OC_chords_presets.h"
+
+namespace OC {
+
+template <typename Owner>
+class ChordEditor {
+public:
+
+  enum EDIT_PAGE {
+  	CHORD_SELECT,
+  	CHORD_EDIT,
+  	CHORD_EDIT_PAGE_LAST
+  };
+
+  void Init() {
+    owner_ = nullptr;
+    cursor_pos_ = 0;
+    cursor_quality_pos_ = 0;
+    edit_this_chord_ = 0;
+    edit_this_progression_ = 0;
+    edit_page_ = CHORD_SELECT;
+    //
+    chord_quality_ = 0;
+    chord_voicing_ = 0;
+    chord_inversion_ = 0;
+    chord_base_note_ = 0;
+    chord_octave_ = 0;
+    max_chords_ = OC::Chords::NUM_CHORDS - 1;
+  }
+
+  bool active() const {
+    return nullptr != owner_;
+  }
+
+  void Edit(Owner *owner, int chord, int num_chords, int num_progression) {
+
+    if (chord > OC::Chords::CHORDS_USER_LAST - 1)
+      return;
+    
+    edit_this_progression_ = num_progression;
+    chord_ = &OC::user_chords[chord + edit_this_progression_ * OC::Chords::NUM_CHORDS];
+    max_chords_ = num_chords;
+    owner_ = owner;
+    BeginEditing();
+  }
+
+  void Close();
+  void Draw();
+  void HandleButtonEvent(const UI::Event &event);
+  void HandleEncoderEvent(const UI::Event &event);
+
+private:
+
+  Owner *owner_;
+  const OC::Chord *chord_;
+  int8_t edit_this_chord_;
+  int8_t edit_this_progression_;
+  size_t cursor_pos_;
+  size_t cursor_quality_pos_;
+  int8_t chord_quality_;
+  int8_t chord_voicing_;
+  int8_t chord_inversion_;
+  int8_t chord_base_note_;
+  int8_t chord_octave_;
+  int8_t max_chords_;
+  bool edit_page_;
+
+  void BeginEditing();
+  void move_cursor(int offset, int page);
+  void update_chord(int8_t chord_num);
+  void copy_chord(); 
+  void paste_chord(); 
+  
+  void change_property(size_t chord_property, int delta, bool notify);
+  void handleButtonLeft(const UI::Event &event);
+  void handleButtonUp(const UI::Event &event);
+  void handleButtonDown(const UI::Event &event);
+};
+
+template <typename Owner>
+void ChordEditor<Owner>::Draw() {
+    
+    weegfx::coord_t w = 128;
+    weegfx::coord_t x = 0;
+    weegfx::coord_t y = 0;
+    weegfx::coord_t h = 64;
+
+    graphics.clearRect(x, y, w, h);
+    graphics.drawFrame(x, y, w, h);
+
+    // chord select:
+    size_t max_chords = max_chords_ + 1;
+    uint8_t indicator = owner_->active_chord();
+    bool active = owner_->get_active_progression() == edit_this_progression_;
+    
+    x = 6;
+    y = 6;
+    // which progression ? ...  
+    graphics.setPrintPos(x, y + 2);
+    graphics.print(edit_this_progression_ + 0x1);
+    // now draw steps:
+    x += 11;
+    
+    for (size_t i = 0; i < max_chords; ++i, x += 13) {
+      
+      if (active && i == indicator) {
+        graphics.drawFrame(x, y, 10, 10);
+        graphics.drawRect(x + 2, y + 2, 6, 6);
+      }
+      else if (edit_page_ == CHORD_SELECT)
+        graphics.drawRect(x, y, 10, 10);
+      else 
+        graphics.drawRect(x + 2, y + 2, 6, 6);  
+        
+      // cursor:
+      if (i == cursor_pos_) 
+        graphics.drawFrame(x - 2, y - 2, 14, 14);
+    }
+
+    // end marker:
+    graphics.drawFrame(x, y, 2, 2);
+    graphics.drawFrame(x, y + 4, 2, 2);
+    graphics.drawFrame(x, y + 8, 2, 2);
+  
+    if (cursor_pos_ == max_chords)
+        graphics.drawFrame(x - 2, y - 2, 6, 14);
+
+    // draw extra cv num chords?
+    if (owner_->get_num_chords_cv()) {
+      int extra_slots = owner_->get_display_num_chords() - (max_chords - 0x1);
+      if (active && extra_slots > 0x0) {
+        x += 5;
+        indicator -= max_chords;
+        for (size_t i = 0; i < (uint8_t)extra_slots; ++i, x += 10) {
+          if (i == indicator)
+            graphics.drawRect(x, y + 2, 6, 6);
+          else
+            graphics.drawFrame(x, y + 2, 6, 6);
+        }
+      }
+    }
+    
+    // chord properties:
+    x = 6;
+    y = 23;
+
+    for (size_t i = 0; i < sizeof(Chord); ++i, x += 24) {
+      
+      // draw values
+    
+      switch(i) {
+        
+          case 0: // quality
+          graphics.setPrintPos(x + 1, y + 7);
+          graphics.print(OC::quality_very_short_names[chord_quality_]);
+          break;
+          case 1: // voicing
+          graphics.setPrintPos(x + 1, y + 7);
+          graphics.print(voicing_names_short[chord_voicing_]);
+          break;
+          case 2: // inversion
+          graphics.setPrintPos(x + 7, y + 7);
+          graphics.print(inversion_names[chord_inversion_]);
+          break;
+          case 3: // base note
+          {
+            if (chord_base_note_ > 9)
+              graphics.setPrintPos(x + 1, y + 7);
+            else
+              graphics.setPrintPos(x + 4, y + 7);
+            graphics.print(base_note_names[chord_base_note_]);
+            // indicate if note is out-of-range:
+            if (chord_base_note_ > (uint8_t)OC::Scales::GetScale(owner_->get_scale(DUMMY)).num_notes) {
+              graphics.drawBitmap8(x + 3, y + 25, 4, OC::bitmap_indicator_4x8);
+              graphics.drawBitmap8(x + 14, y + 25, 4, OC::bitmap_indicator_4x8);
+            }
+          }
+          break;
+          case 4: // octave 
+          {
+          if (chord_octave_ < 0)
+             graphics.setPrintPos(x + 4, y + 7);
+          else
+            graphics.setPrintPos(x + 7, y + 7);
+          graphics.print((int)chord_octave_);
+          }
+          break;
+          default:
+          break;
+      }
+      // draw property name
+      graphics.setPrintPos(x + 7, y + 26);
+      graphics.print(OC::Strings::chord_property_names[i]);
+    
+      // cursor:  
+      if (i == cursor_quality_pos_) {
+        graphics.invertRect(x, y, 21, 21); 
+        if (edit_page_ == CHORD_EDIT)
+          graphics.invertRect(x, y + 22, 21, 14);
+        else 
+          graphics.drawFrame(x, y + 22, 21, 14); 
+      }
+      else {
+        graphics.drawFrame(x, y, 21, 21);
+        graphics.drawFrame(x, y + 22, 21, 14);  
+      }
+    }
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::HandleButtonEvent(const UI::Event &event) {
+
+   if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        handleButtonUp(event);
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        handleButtonDown(event);
+        break;
+      case OC::CONTROL_BUTTON_L:
+        handleButtonLeft(event);
+        break;    
+      case OC::CONTROL_BUTTON_R:
+        Close();
+        break;
+      default:
+        break;
+    }
+  }
+  else if (UI::EVENT_BUTTON_LONG_PRESS == event.type) {
+     switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        // screensaver    // TODO: ideally, needs to be overridden ... invert_mask();
+      break;
+      case OC::CONTROL_BUTTON_DOWN:
+      break;
+      case OC::CONTROL_BUTTON_L: 
+      break;
+      case OC::CONTROL_BUTTON_R:
+       // app menu
+      break;  
+      default:
+      break;
+     }
+  }
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::HandleEncoderEvent(const UI::Event &event) {
+ 
+  if (OC::CONTROL_ENCODER_L == event.control) {
+    move_cursor(event.value, edit_page_);
+  } 
+  else if (OC::CONTROL_ENCODER_R == event.control) {
+
+  	if (cursor_pos_ < (uint8_t)(max_chords_ + 1)) {
+      
+      // write to the right slot, at the right index/offset (a nicer struct would be nicer, but well)
+      OC::Chord *edit_user_chord_ = &OC::user_chords[edit_this_chord_ + edit_this_progression_ * OC::Chords::NUM_CHORDS]; 
+      
+	    switch(cursor_quality_pos_) {
+
+	      case 0: // quality:
+	      {
+	        chord_quality_ += event.value;
+	        CONSTRAIN(chord_quality_, 0, OC::Chords::CHORDS_QUALITY_LAST - 1);
+	        edit_user_chord_->quality = chord_quality_;
+	      }
+	      break;
+	      case 1: // voicing:
+	      {
+	        chord_voicing_ += event.value;
+	        CONSTRAIN(chord_voicing_, 0, OC::Chords::CHORDS_VOICING_LAST - 1);
+	        edit_user_chord_->voicing = chord_voicing_;
+	      }
+	      break;
+	      case 2: // inversion:
+	      {
+	        chord_inversion_ += event.value;
+	        CONSTRAIN(chord_inversion_, 0, OC::Chords::CHORDS_INVERSION_LAST - 1);
+	        edit_user_chord_->inversion = chord_inversion_;
+	      }
+	      break;
+	      case 3: // base note
+	      {
+	        chord_base_note_ += event.value;
+          const OC::Scale &scale_def = OC::Scales::GetScale(owner_->get_scale(DUMMY));
+	        CONSTRAIN(chord_base_note_, 0, (uint8_t)scale_def.num_notes);
+	        edit_user_chord_->base_note = chord_base_note_;
+	      }
+	      break;
+        case 4: // octave
+        {
+          chord_octave_ += event.value;
+          CONSTRAIN(chord_octave_, -4, 4);
+          edit_user_chord_->octave = chord_octave_;
+        }
+        break;
+	      default:
+	      break;
+	    }
+	}
+	else {
+        // expand/contract
+        int max_chords = max_chords_;
+        max_chords += event.value;
+        CONSTRAIN(max_chords, 0, OC::Chords::NUM_CHORDS - 0x1);
+
+        max_chords_ = max_chords;
+        cursor_pos_ = max_chords_ + 1;
+        owner_->set_num_chords(max_chords, edit_this_progression_);
+	  }
+  }
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::update_chord(int8_t chord_num) {
+   // update chord properties:
+   const OC::Chord &chord_def = OC::Chords::GetChord(chord_num, edit_this_progression_); 
+   chord_quality_ = chord_def.quality;
+   chord_voicing_ = chord_def.voicing;
+   chord_inversion_ = chord_def.inversion;
+   chord_base_note_ = chord_def.base_note;
+   chord_octave_ = chord_def.octave;
+   max_chords_ = owner_->get_num_chords(edit_this_progression_);
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::move_cursor(int offset, int page) {
+
+  if (page == CHORD_SELECT) {
+    int cursor_pos = cursor_pos_ + offset;
+    CONSTRAIN(cursor_pos, 0, max_chords_ + 1);  
+    cursor_pos_ = cursor_pos;
+    edit_this_chord_ = cursor_pos; 
+    // update .. 
+    if (cursor_pos <= max_chords_)
+      update_chord(cursor_pos);
+  }
+  else {
+    int cursor_quality_pos = cursor_quality_pos_ + offset;
+    CONSTRAIN(cursor_quality_pos, 0, (int8_t)(sizeof(Chord) - 1)); 
+    cursor_quality_pos_ = cursor_quality_pos;
+  }
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::handleButtonUp(const UI::Event &event) {
+   // go to next chords progression
+   edit_this_progression_++;
+   if (edit_this_progression_ >= OC::Chords::NUM_CHORD_PROGRESSIONS)
+    edit_this_progression_ = 0x0;
+   update_chord(cursor_pos_);
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::handleButtonDown(const UI::Event &event) {
+   // go to previous chords progression
+   edit_this_progression_--;
+   if (edit_this_progression_ < 0x0)
+    edit_this_progression_ = OC::Chords::NUM_CHORD_PROGRESSIONS - 1;
+   update_chord(cursor_pos_);
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::handleButtonLeft(const UI::Event &) {
+
+  if (edit_page_ == CHORD_SELECT) {
+
+    if (cursor_pos_ < (uint8_t)(max_chords_ + 1)) {
+    	edit_page_ = CHORD_EDIT;
+    	// edit chord:
+      edit_this_chord_ = cursor_pos_;
+      update_chord(cursor_pos_);
+    }
+    // select previous chord if clicking on end-marker:
+    else if (cursor_pos_ == (uint8_t)(max_chords_ + 1)) {
+      edit_page_ = CHORD_EDIT;
+      cursor_pos_--;
+      edit_this_chord_ = cursor_pos_;
+    }
+  }
+  else {
+  	edit_page_ = CHORD_SELECT;
+    cursor_pos_ = edit_this_chord_;
+  }
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::copy_chord() {
+ // todo
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::paste_chord() {
+ // todo
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::BeginEditing() {
+
+  cursor_pos_ = edit_this_chord_= owner_->get_chord_slot();
+  const OC::Chord &chord_def = OC::Chords::GetChord(edit_this_chord_, edit_this_progression_);
+  chord_quality_ = chord_def.quality;
+  chord_voicing_ = chord_def.voicing;
+  chord_inversion_ = chord_def.inversion;
+  chord_base_note_ = chord_def.base_note;
+  chord_octave_ = chord_def.octave;
+  edit_page_ = CHORD_SELECT;
+}
+
+template <typename Owner>
+void ChordEditor<Owner>::Close() {
+  ui.SetButtonIgnoreMask();
+  owner_ = nullptr;
+}
+
+}; // namespace OC
+
+#endif // OC_CHORD_EDIT_H_

--- a/software/o_c_REV/OC_chords_presets.h
+++ b/software/o_c_REV/OC_chords_presets.h
@@ -1,0 +1,84 @@
+#ifndef OC_CHORDS_PRESETS_H_
+#define OC_CHORDS_PRESETS_H_
+
+#include "OC_scales.h"
+#include "OC_chords.h"
+#include <Arduino.h>
+
+namespace OC {
+
+  struct Chord {
+   
+    int8_t quality;
+    int8_t inversion;
+    int8_t voicing;
+    int8_t base_note;
+    int8_t octave;
+  };
+
+  const Chord chords[] = {
+    // default
+    { 0, 0, 0, 0, 0 }
+  };
+
+// these intervals are for notes-in-scale/key, last element is the chord type (monad=1, dyad=2, traid=3, tetrad=4)
+ 
+  const int8_t qualities[][4] = 
+  {
+    { 0, 0, 4, 0 },  // fifth
+    { 0, 2, 2, 0 },  // triad 
+    { 0, 2, 2, 2 },  // seventh
+    { 0, 3, 1, 0 },  // suspended
+    { 0, 3, 1, 2 },  // susp. seventh
+    { 0, 2, 2, 1 }, // sixth
+    { 0, 2, 2, 4 }, // added ninth
+    { 0, 2, 2, 6 }, // added eleventh
+    { 0, 0, 0, 0 }, // unisono
+  };
+
+  const int8_t voicing[][4] = 
+  {
+  	// this can't work like this, because it should operate on the inversions, too.
+  	{ 0, 0, 0, 0 },  // close
+  	{ 0, 0, 0, -1},  // drop 1 
+  	{ 0, 0, -1, 0},  // drop 2
+  	{ 0, -1, 0, 0},  // drop 3
+  	{ -1, 1, 1, 1}   // spread
+  };
+
+  const int8_t inversion[][4] {
+    { 0, 0, 0, 0 },
+    { 1, 0, 0, 0 },
+    { 1, 1, 0, 0 },
+    { 1, 1, 1, 0 } 
+  };
+
+  const char* const quality_names[] {
+    "fifth", "triad", "seventh", "suspended", "susp 7th", "sixth", "added 9th", "added 11th", "unisono"
+  };
+
+  const char* const quality_short_names[] {
+    "5th", "triad", "7th", "susp", "sus7", "6th",  "+9th", "+11th", "uni"
+  };
+
+  const char* const quality_very_short_names[] {
+    "5th", "tri", "7th", "sus", "su7", "6th",  "9th", "+11", "uni"
+  };
+
+  const char* const voicing_names[] {
+  	"close", "drop 1", "drop 2", "drop 3", "spread"
+  };
+  
+  const char* const voicing_names_short[] {
+    " - ", "dr1", "dr2", "dr3", "spr"
+  };
+
+  const char* const inversion_names[] {
+    "-", "1", "2", "3"
+  };
+
+  const char* const base_note_names[] {
+    "CV", "#1", "#2", "#3", "#4", "#5", "#6", "#7", "#8", "#9", "#10", "#11", "#12",  "#13",  "#14",  "#15",  "#16"
+  };
+}
+#endif // OC_CHORDS_PRESETS_H_

--- a/software/o_c_REV/OC_options.h
+++ b/software/o_c_REV/OC_options.h
@@ -27,10 +27,13 @@
 /* Flags for the full-width apps, these enable/disable them in OC_apps.ino but also zero out the app   */
 /* files to prevent them from taking up space. Only Enigma is enabled by default.                      */
 #define ENABLE_APP_ENIGMA
-#define ENABLE_APP_MIDI
-#define ENABLE_APP_NEURAL_NETWORK
-#define ENABLE_APP_PONG
-#define ENABLE_APP_DARKEST_TIMELINE
+// #define ENABLE_APP_MIDI
+// #define ENABLE_APP_NEURAL_NETWORK
+// #define ENABLE_APP_PONG
+// #define ENABLE_APP_DARKEST_TIMELINE
+
+#define ENABLE_APP_QUANTERMAIN
+#define ENABLE_APP_METAQ
 
 
 #endif

--- a/software/o_c_REV/OC_options.h
+++ b/software/o_c_REV/OC_options.h
@@ -26,14 +26,17 @@
 
 /* Flags for the full-width apps, these enable/disable them in OC_apps.ino but also zero out the app   */
 /* files to prevent them from taking up space. Only Enigma is enabled by default.                      */
-#define ENABLE_APP_ENIGMA
+// #define ENABLE_APP_ENIGMA
 // #define ENABLE_APP_MIDI
 // #define ENABLE_APP_NEURAL_NETWORK
 // #define ENABLE_APP_PONG
 // #define ENABLE_APP_DARKEST_TIMELINE
 
+// Stock O&C apps
 #define ENABLE_APP_QUANTERMAIN
 #define ENABLE_APP_METAQ
+#define ENABLE_APP_CHORDS
+#define ENABLE_APP_SEQUINS
 
 
 #endif

--- a/software/o_c_REV/OC_options.h
+++ b/software/o_c_REV/OC_options.h
@@ -25,7 +25,10 @@
 //#define DAC8564
 
 /* Flags for the full-width apps, these enable/disable them in OC_apps.ino but also zero out the app   */
-/* files to prevent them from taking up space. Only Enigma is enabled by default.                      */
+/* files to prevent them from taking up space.                                                         */
+// Sets of these are now defined in platformio.ini for convenience. -NJM
+
+// Hemisphere apps
 // #define ENABLE_APP_ENIGMA
 // #define ENABLE_APP_MIDI
 // #define ENABLE_APP_NEURAL_NETWORK
@@ -33,10 +36,10 @@
 // #define ENABLE_APP_DARKEST_TIMELINE
 
 // Stock O&C apps
-#define ENABLE_APP_QUANTERMAIN
-#define ENABLE_APP_METAQ
-#define ENABLE_APP_CHORDS
-#define ENABLE_APP_SEQUINS
+// #define ENABLE_APP_QUANTERMAIN
+// #define ENABLE_APP_METAQ
+// #define ENABLE_APP_CHORDS
+// #define ENABLE_APP_SEQUINS
 
 
 #endif

--- a/software/o_c_REV/OC_scale_edit.h
+++ b/software/o_c_REV/OC_scale_edit.h
@@ -1,0 +1,656 @@
+#ifndef OC_SCALE_EDIT_H_
+#define OC_SCALE_EDIT_H_
+
+#include "OC_bitmaps.h"
+#include "OC_strings.h"
+#include "OC_DAC.h"
+
+namespace OC {
+
+// Scale editor
+// Edits both scale length and note note values, as well as a mask of "active"
+// notes that the quantizer uses; some scales are read-only, in which case
+// only the mask is editable
+//
+// The owner class needs to provide callbacks to get notification when values
+// change: see ASR, A_SEQ, DQ, etc for details
+//
+
+const bool DUMMY = false;
+
+enum SCALE_EDIT_PAGES {
+  _SCALE,
+  _ROOT,
+  _TRANSPOSE,
+  _SCALING
+};
+
+template <typename Owner>
+class ScaleEditor {
+public:
+
+  void Init(bool mode) {
+    owner_ = nullptr;
+    scale_name_ = "?!";
+    scale_ = mutable_scale_ = &dummy_scale;
+    mask_ = 0;
+    cursor_pos_ = 0;
+    scaling_cursor_pos_ = 0;
+    num_notes_ = 0;
+    edit_this_scale_ = 0;
+    /* mode: true = Meta-Q; false = scale editor */
+    SEQ_MODE = mode;
+    edit_page_ = _SCALE;
+    ticks_ = 0;
+  }
+
+  bool active() const {
+    return nullptr != owner_;
+  }
+
+  void Edit(Owner *owner, int scale) {
+    if (OC::Scales::SCALE_NONE == scale)
+      return;
+
+    if (scale < OC::Scales::SCALE_USER_LAST) {
+      scale_ = mutable_scale_ = &OC::user_scales[scale];
+      scale_name_ = OC::scale_names_short[scale];
+      // Serial.print("Editing mutable scale "); 
+      // Serial.println(scale_name_);
+    } else {
+      scale_ = &OC::Scales::GetScale(scale);
+      mutable_scale_ = nullptr;
+      scale_name_ = OC::scale_names_short[scale];
+      // Serial.print("Editing const scale "); 
+      // Serial.println(scale_name_);
+    }
+    owner_ = owner;
+    BeginEditing(SEQ_MODE);
+  }
+
+  void Close();
+  void Draw();
+  void HandleButtonEvent(const UI::Event &event);
+  void HandleEncoderEvent(const UI::Event &event);
+  static uint16_t RotateMask(uint16_t mask, int num_notes, int amount);
+
+private:
+
+  Owner *owner_;
+  const char * scale_name_;
+  const braids::Scale *scale_;
+  Scale *mutable_scale_;
+
+  uint16_t mask_;
+  size_t cursor_pos_;
+  size_t scaling_cursor_pos_;
+  size_t num_notes_;
+  int8_t edit_this_scale_;
+  bool SEQ_MODE;
+  uint8_t edit_page_; 
+  uint32_t ticks_;
+
+  void BeginEditing(bool mode);
+  void move_cursor(int offset);
+
+  void toggle_mask();
+  void invert_mask(); 
+
+  void apply_mask(uint16_t mask) {
+    
+    if (mask_ != mask) {
+      mask_ = mask;
+      owner_->update_scale_mask(mask_, edit_this_scale_);
+    }
+  }
+
+  void reset_scale();
+  void change_note(size_t pos, int delta, bool notify);
+  void handleButtonLeft(const UI::Event &event);
+  void handleButtonUp(const UI::Event &event);
+  void handleButtonDown(const UI::Event &event);
+};
+
+template <typename Owner>
+void ScaleEditor<Owner>::Draw() {
+
+  if (edit_page_ < _SCALING) {
+  
+    size_t num_notes = num_notes_;
+    static constexpr weegfx::coord_t kMinWidth = 64;
+    weegfx::coord_t w =
+      mutable_scale_ ? ((num_notes + 1) * 7) : (num_notes * 7);
+  
+    if (w < kMinWidth || (edit_page_ == _ROOT) || (edit_page_ == _TRANSPOSE)) w = kMinWidth;
+  
+    weegfx::coord_t x = 64 - (w + 1) / 2;
+    weegfx::coord_t y = 16 - 3;
+    weegfx::coord_t h = 36;
+  
+    graphics.clearRect(x, y, w + 4, h);
+    graphics.drawFrame(x, y, w + 5, h);
+  
+    x += 2;
+    y += 3;
+  
+    graphics.setPrintPos(x, y);
+    graphics.print(scale_name_);
+    
+    if (SEQ_MODE) {
+      ticks_++;
+      uint8_t id = edit_this_scale_;
+      if (edit_this_scale_ == owner_->get_scale_select())
+        id += 4;
+      graphics.print(OC::Strings::scale_id[id]);
+    }
+  
+    if (SEQ_MODE && edit_page_) {
+  
+      switch (edit_page_) {
+  
+        case _ROOT:
+        case _TRANSPOSE: {
+          x += w / 2 - (25 + 3); y += 10;
+          graphics.drawFrame(x, y, 25, 20);
+          graphics.drawFrame(x + 32, y, 25, 20);
+          // print root:
+          int root = owner_->get_root(edit_this_scale_);
+          if (root == 1 || root == 3 || root == 6 || root == 8 || root == 10)
+            graphics.setPrintPos(x + 7, y + 7);
+          else 
+            graphics.setPrintPos(x + 9, y + 7);
+          graphics.print(OC::Strings::note_names_unpadded[root]);
+          // print transpose:
+          int transpose = owner_->get_transpose(edit_this_scale_);
+          graphics.setPrintPos(x + 32 + 5, y + 7);
+          if (transpose >= 0)
+            graphics.print("+");
+          graphics.print(transpose);
+          // draw cursor
+          if (edit_page_ == _ROOT)
+            graphics.invertRect(x - 1, y - 1, 27, 22); 
+          else
+            graphics.invertRect(x + 32 - 1, y - 1, 27, 22);
+        }
+        break;
+        default:
+        break;
+      } 
+    }
+    else {
+      // edit scale    
+      graphics.setPrintPos(x, y + 24);
+      if (cursor_pos_ != num_notes) {
+        graphics.movePrintPos(weegfx::Graphics::kFixedFontW, 0);
+        if (mutable_scale_ && OC::ui.read_immediate(OC::CONTROL_BUTTON_L))
+          graphics.drawBitmap8(x + 1, y + 23, kBitmapEditIndicatorW, bitmap_edit_indicators_8);
+        else if (mutable_scale_)
+          graphics.drawBitmap8(x + 1, y + 23, 4, bitmap_indicator_4x8);
+    
+        uint32_t note_value = scale_->notes[cursor_pos_];
+        uint32_t cents = (note_value * 100) >> 7;
+        uint32_t frac_cents = ((note_value * 100000) >> 7) - cents * 1000;
+        // move print position, so that things look somewhat nicer
+        if (cents < 10)
+          graphics.movePrintPos(weegfx::Graphics::kFixedFontW * -3, 0);
+        else if (cents < 100)
+          graphics.movePrintPos(weegfx::Graphics::kFixedFontW * -2, 0);
+        else if (cents < 1000)
+          graphics.movePrintPos(weegfx::Graphics::kFixedFontW * -1, 0);
+        // justify left ...  
+        if (! mutable_scale_)
+          graphics.movePrintPos(weegfx::Graphics::kFixedFontW * -1, 0);
+        graphics.printf("%4u.%02uc", cents, (frac_cents + 5) / 10);
+    
+      } else {
+        graphics.print((int)num_notes);
+      }
+  
+      x += mutable_scale_ ? (w >> 0x1) - (((num_notes) * 7 + 4) >> 0x1) : (w >> 0x1) - (((num_notes - 1) * 7 + 4) >> 0x1); 
+      y += 11;
+      uint16_t mask = mask_;
+      for (size_t i = 0; i < num_notes; ++i, x += 7, mask >>= 1) {
+        if (mask & 0x1)
+          graphics.drawRect(x, y, 4, 8);
+        else
+          graphics.drawBitmap8(x, y, 4, bitmap_empty_frame4x8);
+    
+        if (i == cursor_pos_)
+          graphics.drawFrame(x - 2, y - 2, 8, 12);
+      }
+      if (mutable_scale_) {
+        graphics.drawBitmap8(x, y, 4, bitmap_end_marker4x8);
+        if (cursor_pos_ == num_notes)
+          graphics.drawFrame(x - 2, y - 2, 8, 12);
+      }
+    }
+  }
+  else {
+    // scaling ... 
+    weegfx::coord_t x = 0;
+    weegfx::coord_t y = 0;
+    weegfx::coord_t h = 64;
+    weegfx::coord_t w = 128;
+  
+    graphics.clearRect(x, y, w, h);
+    graphics.drawFrame(x, y, w, h);
+
+    x += 5;
+    y += 5;
+    graphics.setPrintPos(x, y);
+    graphics.print(OC::Strings::scaling_string[0]);
+    graphics.print(OC::Strings::channel_id[DAC_CHANNEL_A]);
+    graphics.setPrintPos(x + 87, y);
+    graphics.print(OC::voltage_scalings[OC::DAC::get_voltage_scaling(DAC_CHANNEL_A)]);
+    y += 16;
+    graphics.setPrintPos(x, y);
+    graphics.print(OC::Strings::scaling_string[0]);
+    graphics.print(OC::Strings::channel_id[DAC_CHANNEL_B]);
+    graphics.setPrintPos(x + 87, y);
+    graphics.print(OC::voltage_scalings[OC::DAC::get_voltage_scaling(DAC_CHANNEL_B)]);
+    y += 16;
+    graphics.setPrintPos(x, y);
+    graphics.print(OC::Strings::scaling_string[0]);
+    graphics.print(OC::Strings::channel_id[DAC_CHANNEL_C]);
+    graphics.setPrintPos(x + 87, y);
+    graphics.print(OC::voltage_scalings[OC::DAC::get_voltage_scaling(DAC_CHANNEL_C)]);
+    y += 16;
+    graphics.setPrintPos(x, y);
+    graphics.print(OC::Strings::scaling_string[0]);
+    graphics.print(OC::Strings::channel_id[DAC_CHANNEL_D]);
+    graphics.setPrintPos(x + 87, y);
+    graphics.print(OC::voltage_scalings[OC::DAC::get_voltage_scaling(DAC_CHANNEL_D)]);
+    // draw cursor:
+    graphics.invertRect(x - 2, (scaling_cursor_pos_ << 4) + 3, w - 6, 11);
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::HandleButtonEvent(const UI::Event &event) {
+  if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        handleButtonUp(event);
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        handleButtonDown(event);
+        break;
+      case OC::CONTROL_BUTTON_L:
+        handleButtonLeft(event);
+        break;
+      case OC::CONTROL_BUTTON_R:
+      {
+        if (edit_page_ < _SCALING)
+          Close();
+        else
+          edit_page_ = _SCALE;
+      }
+      break;
+      default:
+      break;
+    }
+  }
+  else if (UI::EVENT_BUTTON_LONG_PRESS == event.type) {
+    
+     switch (event.control) {
+      case OC::CONTROL_BUTTON_L:
+      {
+        if (edit_page_ < _SCALING)
+          edit_page_ = _SCALING;
+      }
+      break;
+      default:
+      {
+        if (edit_page_ == _SCALING)
+          edit_page_ = _SCALE;
+      }
+      break;
+     }
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::HandleEncoderEvent(const UI::Event &event) {
+  bool scale_changed = false;
+  uint16_t mask = mask_;
+
+  if (OC::CONTROL_ENCODER_L == event.control) {
+    
+    if (SEQ_MODE && OC::ui.read_immediate(OC::CONTROL_BUTTON_UP)) {
+      
+          // we're in Meta-Q, so we can change the scale:
+         
+          int _scale = owner_->get_scale(edit_this_scale_) + event.value;
+          CONSTRAIN(_scale, OC::Scales::SCALE_USER_0, OC::Scales::NUM_SCALES-1);
+          
+          if (_scale == OC::Scales::SCALE_NONE) {
+             // just skip this here ...
+             if (event.value > 0) 
+                _scale++;
+             else 
+                _scale--;
+          }
+          // update active scale with mask/root/transpose settings, and set flag:
+          owner_->set_scale_at_slot(_scale, mask_, owner_->get_root(edit_this_scale_), owner_->get_transpose(edit_this_scale_), edit_this_scale_); 
+          scale_changed = true; 
+          
+          if (_scale < OC::Scales::SCALE_USER_LAST) {
+            scale_ = mutable_scale_ = &OC::user_scales[_scale];
+            scale_name_ = OC::scale_names_short[_scale];
+          } 
+          else {
+            scale_ = &OC::Scales::GetScale(_scale);
+            mutable_scale_ = nullptr;
+            scale_name_ = OC::scale_names_short[_scale];
+          }
+          cursor_pos_ = 0;
+          num_notes_ = scale_->num_notes;
+          mask_ = owner_->get_scale_mask(edit_this_scale_); // ? can go, because the mask didn't change
+          ticks_ = 0;
+    }
+    else {
+      move_cursor(event.value);
+    }
+  } else if (OC::CONTROL_ENCODER_R == event.control) {
+
+      switch (edit_page_) {
+
+        case _SCALE: 
+        {
+          bool handled = false;
+          if (mutable_scale_) {
+            if (cursor_pos_ < num_notes_) {
+              if (event.mask & OC::CONTROL_BUTTON_L) {
+                OC::ui.IgnoreButton(OC::CONTROL_BUTTON_L);
+                change_note(cursor_pos_, event.value, false);
+                scale_changed = true;
+                handled = true;
+              }
+            } else {
+              if (cursor_pos_ == num_notes_) {
+                int num_notes = num_notes_;
+                num_notes += event.value;
+                CONSTRAIN(num_notes, kMinScaleLength, kMaxScaleLength);
+      
+                num_notes_ = num_notes;
+                if (event.value > 0) {
+                  for (size_t pos = cursor_pos_; pos < num_notes_; ++pos)
+                    change_note(pos, 0, false);
+      
+                  // Enable new notes by default
+                  mask |= ~(0xffff << (num_notes_ - cursor_pos_)) << cursor_pos_;
+                } else {
+                  // scale might be shortened to where no notes are active in mask
+                  if (0 == (mask & ~(0xffff < num_notes_)))
+                    mask |= 0x1;
+                }
+      
+                mutable_scale_->num_notes = num_notes_;
+                cursor_pos_ = num_notes_;
+                handled = scale_changed = true;
+              }
+            }
+          }
+          if (!handled) {
+              mask = RotateMask(mask_, num_notes_, event.value);
+          }
+        }
+        break;
+        case _ROOT:
+        {
+         int _root = owner_->get_root(edit_this_scale_) + event.value;
+         CONSTRAIN(_root, 0, 11);
+         owner_->set_scale_at_slot(owner_->get_scale(edit_this_scale_), mask_, _root, owner_->get_transpose(edit_this_scale_), edit_this_scale_); 
+        }
+        break;
+        case _TRANSPOSE: 
+        {
+         int _transpose = owner_->get_transpose(edit_this_scale_) + event.value;
+         CONSTRAIN(_transpose, -12, 12);
+         owner_->set_scale_at_slot(owner_->get_scale(edit_this_scale_), mask_, owner_->get_root(edit_this_scale_), _transpose, edit_this_scale_); 
+        }
+        break;
+        case _SCALING:
+        {
+         int item = scaling_cursor_pos_ + event.value;
+         CONSTRAIN(item, DAC_CHANNEL_A, DAC_CHANNEL_LAST - 0x1);
+         scaling_cursor_pos_ = item;
+        }
+        break;
+        default:
+        break;
+      }
+  }
+  // This isn't entirely atomic
+  apply_mask(mask);
+  if (scale_changed)
+    owner_->scale_changed();
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::move_cursor(int offset) {
+
+  switch (edit_page_) {
+
+    case _ROOT:
+    case _TRANSPOSE:
+    {
+      int8_t item = edit_page_ + offset;
+      CONSTRAIN(item, _ROOT, _TRANSPOSE);
+      edit_page_ = item;  
+    }  
+    break;
+    case _SCALING:
+    {
+      int8_t scaling = OC::DAC::get_voltage_scaling(scaling_cursor_pos_) + offset;
+      CONSTRAIN(scaling, VOLTAGE_SCALING_1V_PER_OCT, VOLTAGE_SCALING_LAST - 0x1);
+      OC::DAC::set_scaling(scaling, scaling_cursor_pos_);
+    }
+    break;
+    default:
+    {
+      int cursor_pos = cursor_pos_ + offset;
+      const int max = mutable_scale_ ? num_notes_ : num_notes_ - 1;
+      CONSTRAIN(cursor_pos, 0, max);
+      cursor_pos_ = cursor_pos;
+    }
+    break;
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::handleButtonUp(const UI::Event &event) {
+
+  if (event.mask & OC::CONTROL_BUTTON_L) {
+    OC::ui.IgnoreButton(OC::CONTROL_BUTTON_L);
+    if (cursor_pos_ == num_notes_)
+      reset_scale();
+    else
+      change_note(cursor_pos_, 128, true);
+  } else {
+    if (!SEQ_MODE)
+      invert_mask();
+    else {
+      
+      if (ticks_ > 250) {
+        edit_this_scale_++;  
+        if (edit_this_scale_ > 0x3) 
+          edit_this_scale_ = 0;
+          
+        uint8_t scale = owner_->get_scale(edit_this_scale_);  
+        // Serial.println(scale);
+        if (scale < OC::Scales::SCALE_USER_LAST) {
+          scale_ = mutable_scale_ = &OC::user_scales[scale];
+          scale_name_ = OC::scale_names_short[scale];
+          // Serial.print("Editing mutable scale "); 
+          // Serial.println(scale_name_);
+         } 
+         else {
+          scale_ = &OC::Scales::GetScale(scale);
+          mutable_scale_ = nullptr;
+          scale_name_ = OC::scale_names_short[scale];
+          // Serial.print("Editing const scale "); 
+          // Serial.println(scale_name_);
+        }
+        cursor_pos_ = 0;
+        num_notes_ = scale_->num_notes;
+        mask_ = owner_->get_scale_mask(edit_this_scale_);  
+      }
+    }
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::handleButtonDown(const UI::Event &event) {
+  if (event.mask & OC::CONTROL_BUTTON_L) {
+    OC::ui.IgnoreButton(OC::CONTROL_BUTTON_L);
+    change_note(cursor_pos_, -128, true);
+  } else {
+    if (!SEQ_MODE)
+      invert_mask();
+    else {
+      
+      if (ticks_ > 250) {
+        edit_this_scale_--;  
+        if (edit_this_scale_ < 0) 
+          edit_this_scale_ = 3; 
+          
+        uint8_t scale = owner_->get_scale(edit_this_scale_);  
+        // Serial.println(scale);
+        if (scale < OC::Scales::SCALE_USER_LAST) {
+          scale_ = mutable_scale_ = &OC::user_scales[scale];
+          scale_name_ = OC::scale_names_short[scale];
+          // Serial.print("Editing mutable scale "); 
+          // Serial.println(scale_name_);
+         } 
+         else {
+          scale_ = &OC::Scales::GetScale(scale);
+          mutable_scale_ = nullptr;
+          scale_name_ = OC::scale_names_short[scale];
+          // Serial.print("Editing const scale "); 
+          // Serial.println(scale_name_);
+        }
+        cursor_pos_ = 0;
+        num_notes_ = scale_->num_notes;
+        mask_ = owner_->get_scale_mask(edit_this_scale_);
+      }
+    }
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::handleButtonLeft(const UI::Event &) {
+
+  if (SEQ_MODE && OC::ui.read_immediate(OC::CONTROL_BUTTON_UP)) {
+
+    if (edit_page_ == _SCALE) 
+      edit_page_ = _ROOT; // switch to root
+    // and don't accidentally change scale slot:  
+    ticks_ = 0x0;
+  }
+  else { 
+    // edit scale mask
+    if (edit_page_ > _SCALE)
+      edit_page_ = _SCALE;
+    else {
+      uint16_t m = 0x1 << cursor_pos_;
+      uint16_t mask = mask_;
+    
+      if (cursor_pos_ < num_notes_) {
+        // toggle note active state; avoid 0 mask
+        if (mask & m) {
+          if ((mask & ~(0xffff << num_notes_)) != m)
+            mask &= ~m;
+        } else {
+          mask |= m;
+        }
+        apply_mask(mask);
+      } 
+    }
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::invert_mask() {
+  uint16_t m = ~(0xffffU << num_notes_);
+  uint16_t mask = mask_;
+  // Don't invert to zero
+  if ((mask & m) != m)
+    mask ^= m;
+  apply_mask(mask);
+}
+
+template <typename Owner>
+/*static*/ uint16_t ScaleEditor<Owner>::RotateMask(uint16_t mask, int num_notes, int amount) {
+  uint16_t used_bits = ~(0xffffU << num_notes);
+  mask &= used_bits;
+
+  if (amount < 0) {
+    amount = -amount % num_notes;
+    mask = (mask >> amount) | (mask << (num_notes - amount));
+  } else {
+    amount = amount % num_notes;
+    mask = (mask << amount) | (mask >> (num_notes - amount));
+  }
+  return mask | ~used_bits; // fill upper bits
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::reset_scale() {
+  // Serial.println("Resetting scale to SEMI");
+
+  *mutable_scale_ = OC::Scales::GetScale(OC::Scales::SCALE_SEMI);
+  num_notes_ = mutable_scale_->num_notes;
+  cursor_pos_ = num_notes_;
+  mask_ = ~(0xfff << num_notes_);
+  apply_mask(mask_);
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::change_note(size_t pos, int delta, bool notify) {
+  if (mutable_scale_ && pos < num_notes_) {
+    int32_t note = mutable_scale_->notes[pos] + delta;
+
+    const int32_t min = pos > 0 ? mutable_scale_->notes[pos - 1] : 0;
+    const int32_t max = pos < num_notes_ - 1 ? mutable_scale_->notes[pos + 1] : mutable_scale_->span;
+
+    // TODO It's probably possible to construct a pothological scale,
+    // maybe factor cursor_pos into it somehow?
+    if (note <= min) note = pos > 0 ? min + 1 : 0;
+    if (note >= max) note = max - 1;
+    mutable_scale_->notes[pos] = note;
+//    braids::SortScale(*mutable_scale_); // TODO side effects?
+
+    if (notify)
+      owner_->scale_changed();
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::BeginEditing(bool mode) {
+
+  cursor_pos_ = 0;
+  num_notes_ = scale_->num_notes; 
+   
+  if (mode) { // == meta-Q
+    edit_this_scale_ = owner_->get_scale_select();
+    mask_ = owner_->get_scale_mask(edit_this_scale_);
+    OC::ui._preemptScreensaver(true);
+  }
+  else { 
+    mask_ = owner_->get_scale_mask(DUMMY); 
+  }
+}
+
+template <typename Owner>
+void ScaleEditor<Owner>::Close() {
+  ui.SetButtonIgnoreMask();
+  OC::ui._preemptScreensaver(false);
+  owner_ = nullptr;
+  edit_this_scale_ = 0;
+  edit_page_ = _SCALE;
+}
+
+}; // namespace OC
+
+#endif // OC_SCALE_EDIT_H_

--- a/software/o_c_REV/OC_sequence_edit.h
+++ b/software/o_c_REV/OC_sequence_edit.h
@@ -1,0 +1,422 @@
+#ifndef OC_SEQUENCE_EDIT_H_
+#define OC_SEQUENCE_EDIT_H_
+
+#include "OC_bitmaps.h"
+#include "OC_patterns.h"
+#include "OC_patterns_presets.h"
+#include "OC_options.h"
+
+namespace OC {
+
+// Pattern editor
+// based on scale editor written by Patrick Dowling, adapted for TU, re-adapted for OC
+//
+
+template <typename Owner>
+class PatternEditor {
+public:
+
+  void Init() {
+    owner_ = nullptr;
+    pattern_name_ = "?!";
+    pattern_ = mutable_pattern_ = &dummy_pattern;
+    mask_ = 0;
+    cursor_pos_ = 0;
+    num_slots_ = 0;
+    edit_this_sequence_ = 0;
+  }
+
+  bool active() const {
+    return nullptr != owner_;
+  }
+
+  void Edit(Owner *owner, int pattern) {
+    if (OC::Patterns::PATTERN_NONE == pattern)
+      return;
+
+    pattern_ = mutable_pattern_ = &OC::user_patterns[pattern];
+    pattern_name_ = OC::pattern_names_short[pattern];
+    // Serial.print("Editing user pattern ");
+    // Serial.println(pattern_name_);
+    owner_ = owner;
+
+    BeginEditing();
+  }
+
+  void Close();
+
+  void Draw();
+  void HandleButtonEvent(const UI::Event &event);
+  void HandleEncoderEvent(const UI::Event &event);
+  static uint16_t RotateMask(uint16_t mask, int num_slots, int amount);
+
+private:
+
+  Owner *owner_;
+  const char * pattern_name_;
+  const OC::Pattern *pattern_;
+  Pattern *mutable_pattern_;
+
+  uint16_t mask_;
+  int8_t edit_this_sequence_;
+  size_t cursor_pos_;
+  size_t num_slots_;
+
+  void BeginEditing();
+
+  void move_cursor(int offset);
+  void toggle_mask();
+  void invert_mask();
+  void clear_mask();
+  void copy_sequence();
+  void paste_sequence();
+
+  void apply_mask(uint16_t mask) {
+
+    if (mask_ != mask) {
+      mask_ = mask;
+      owner_->update_pattern_mask(mask_, edit_this_sequence_);
+    }
+
+    bool force = (owner_->get_current_sequence() == edit_this_sequence_);
+    owner_->pattern_changed(mask, force);
+  }
+
+  void change_slot(size_t pos, int delta, bool notify);
+  void handleButtonLeft(const UI::Event &event);
+  void handleButtonUp(const UI::Event &event);
+  void handleButtonDown(const UI::Event &event);
+};
+
+template <typename Owner>
+void PatternEditor<Owner>::Draw() {
+  size_t num_slots = num_slots_;
+
+  weegfx::coord_t const w = 128;
+  weegfx::coord_t const h = 64;
+  weegfx::coord_t x = 0;
+  weegfx::coord_t y = 0;
+  graphics.clearRect(x, y, w, h);
+  graphics.drawFrame(x, y, w, h);
+
+  x += 2;
+  y += 3;
+
+  graphics.setPrintPos(x, y);
+
+  uint8_t id = edit_this_sequence_;
+
+  if (edit_this_sequence_ == owner_->get_sequence())
+    graphics.printf("#%d", id + 1);
+  else {
+    graphics.drawBitmap8(x, y, 4, OC::bitmap_indicator_4x8);
+    graphics.setPrintPos(x + 4, y);
+    graphics.print(id + 1);
+  }
+
+  if (cursor_pos_ == num_slots) {
+    // print length
+    graphics.print(":");
+    if (num_slots > 9)
+        graphics.print((int)num_slots, 2);
+      else
+        graphics.print((int)num_slots, 1);
+  }
+  else {
+    // print pitch value at current step  ...
+    // 0 -> 0V, 1536 -> 1V, 3072 -> 2V
+    int pitch = (int)owner_->get_pitch_at_step(edit_this_sequence_, cursor_pos_);
+    int32_t octave = pitch / (12 << 7);
+    int32_t frac = pitch - octave * (12 << 7);
+    int32_t cents = (int)((float)(frac%128)/1.28);
+    int32_t pClass = (int)floor(frac/128);
+    octave += owner_->get_octave();
+    if (pitch < 0) {
+      pClass = (pClass+12)%12;
+      if (frac < -127) {
+        octave--;
+      }
+      graphics.printf(": %s%d %dc (%d)", OC::Strings::note_names_unpadded[pClass], octave, cents, frac%128); //, (float)frac / 128.0f);
+    } else {
+      graphics.printf(": %s%d +%dc (%d)", OC::Strings::note_names_unpadded[pClass], octave, cents, frac%128); //, (float)frac / 128.0f);
+    }
+  }
+
+  x += 3 + (w >> 0x1) - (num_slots << 0x2); y += 40;
+  #ifdef BUCHLA_4U
+    y += 16;
+  #endif
+
+  uint8_t clock_pos= owner_->get_clock_cnt();
+  bool _draw_clock = (owner_->get_current_sequence() == edit_this_sequence_) && owner_->draw_clock();
+  uint16_t mask = mask_;
+
+  for (size_t i = 0; i < num_slots; ++i, x += 7, mask >>= 1) {
+
+    int pitch = (int)owner_->get_pitch_at_step(edit_this_sequence_, i);
+
+    bool _clock = (i == clock_pos && _draw_clock);
+
+    if (mask & 0x1 & (pitch >= 0)) {
+      pitch += 0x100;
+      if (_clock)
+        graphics.drawRect(x - 1, y - (pitch >> 8), 6, pitch >> 8);
+      else
+        graphics.drawRect(x, y - (pitch >> 8), 4, pitch >> 8);
+    }
+    else if (mask & 0x1) {
+      pitch -= 0x100;
+      if (_clock)
+        graphics.drawRect(x - 1, y, 6, abs(pitch) >> 8);
+      else
+        graphics.drawRect(x, y, 4, abs(pitch) >> 8);
+    }
+    else if (pitch > - 0x200 && pitch < 0x200) {
+     // disabled steps not visible otherwise..
+     graphics.drawRect(x + 1, y - 1, 2, 2);
+    }
+    else if (pitch >= 0) {
+      pitch += 0x100;
+      graphics.drawFrame(x, y - (pitch >> 8), 4, pitch >> 8);
+    }
+    else {
+      pitch -= 0x100;
+      graphics.drawFrame(x, y, 4, abs(pitch) >> 8);
+    }
+
+    if (i == cursor_pos_) {
+      if (OC::ui.read_immediate(OC::CONTROL_BUTTON_L))
+        graphics.drawFrame(x - 3, y - 5, 10, 10);
+      else
+        graphics.drawFrame(x - 2, y - 4, 8, 8);
+    }
+
+    if (_clock)
+      graphics.drawRect(x, y + 17, 4, 2);
+
+  }
+  if (mutable_pattern_) {
+     graphics.drawFrame(x, y - 2, 4, 4);
+    if (cursor_pos_ == num_slots)
+      graphics.drawFrame(x - 2, y - 4, 8, 8);
+  }
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::HandleButtonEvent(const UI::Event &event) {
+
+   if (UI::EVENT_BUTTON_PRESS == event.type) {
+    switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        handleButtonUp(event);
+        break;
+      case OC::CONTROL_BUTTON_DOWN:
+        handleButtonDown(event);
+        break;
+      case OC::CONTROL_BUTTON_L:
+        handleButtonLeft(event);
+        break;
+      case OC::CONTROL_BUTTON_R:
+        Close();
+        break;
+      default:
+        break;
+    }
+  }
+  else if (UI::EVENT_BUTTON_LONG_PRESS == event.type) {
+     switch (event.control) {
+      case OC::CONTROL_BUTTON_UP:
+        // screensaver    // TODO: ideally, needs to be overridden ... invert_mask();
+      break;
+      case OC::CONTROL_BUTTON_DOWN:
+      {
+        if (OC::ui.read_immediate(OC::CONTROL_BUTTON_L))
+          clear_mask();
+        else
+          paste_sequence();
+      }
+      break;
+      case OC::CONTROL_BUTTON_L:
+      {
+        if (OC::ui.read_immediate(OC::CONTROL_BUTTON_DOWN))
+          clear_mask();
+        else
+          copy_sequence();
+      }
+      break;
+      case OC::CONTROL_BUTTON_R:
+       // app menu
+      break;
+      default:
+      break;
+     }
+  }
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::HandleEncoderEvent(const UI::Event &event) {
+
+  uint16_t mask = mask_;
+
+  if (OC::CONTROL_ENCODER_L == event.control) {
+    move_cursor(event.value);
+  } else if (OC::CONTROL_ENCODER_R == event.control) {
+    bool handled = false;
+    if (mutable_pattern_) {
+      if (cursor_pos_ >= num_slots_) {
+
+        if (cursor_pos_ == num_slots_) {
+          int num_slots = num_slots_;
+          num_slots += event.value;
+          CONSTRAIN(num_slots, kMinPatternLength, kMaxPatternLength);
+
+          num_slots_ = num_slots;
+           if (event.value > 0) {
+            // erase  slots when expanding?
+            if (OC::ui.read_immediate(OC::CONTROL_BUTTON_L)) {
+               mask &= ~(~(0xffff << (num_slots_ - cursor_pos_)) << cursor_pos_);
+               owner_->set_pitch_at_step(edit_this_sequence_, num_slots_, 0x0);
+            }
+          }
+          // empty patterns are ok --
+          owner_->set_sequence_length(num_slots_, edit_this_sequence_);
+          cursor_pos_ = num_slots_;
+          handled = true;
+        }
+      }
+    }
+
+    if (!handled) {
+
+      int32_t pitch = owner_->get_pitch_at_step(edit_this_sequence_, cursor_pos_);
+      // Q? might be better to actually add whatever is in the scale
+      // or semitone/finetune?
+      int16_t delta = event.value;
+      if (OC::ui.read_immediate(OC::CONTROL_BUTTON_L))
+       pitch += delta; // fine
+      else
+        pitch += (delta << 7); // semitone
+      #ifdef BUCHLA_4U
+        CONSTRAIN(pitch, 0x0, 8 * (12 << 7)  - 128);
+      #else
+        CONSTRAIN(pitch, -3 * (12 << 7), 5 * (12 << 7)  - 128);
+      #endif
+      owner_->set_pitch_at_step(edit_this_sequence_, cursor_pos_, pitch);
+
+    }
+  }
+  // This isn't entirely atomic
+  apply_mask(mask);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::move_cursor(int offset) {
+
+  int cursor_pos = cursor_pos_ + offset;
+  const int max = mutable_pattern_ ? num_slots_ : num_slots_ - 1;
+  CONSTRAIN(cursor_pos, 0, max);
+  cursor_pos_ = cursor_pos;
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::handleButtonUp(const UI::Event &event) {
+
+    // next pattern / edit 'offline':
+    edit_this_sequence_++;
+    if (edit_this_sequence_ > OC::Patterns::PATTERN_USER_LAST-1)
+      edit_this_sequence_ = 0;
+
+    cursor_pos_ = 0;
+    num_slots_ = owner_->get_sequence_length(edit_this_sequence_);
+    mask_ = owner_->get_mask(edit_this_sequence_);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::handleButtonDown(const UI::Event &event) {
+
+    // next pattern / edit 'offline':
+    edit_this_sequence_--;
+    if (edit_this_sequence_ < 0)
+      edit_this_sequence_ = OC::Patterns::PATTERN_USER_LAST-1;
+
+    cursor_pos_ = 0;
+    num_slots_ = owner_->get_sequence_length(edit_this_sequence_);
+    mask_ = owner_->get_mask(edit_this_sequence_);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::handleButtonLeft(const UI::Event &) {
+  uint16_t m = 0x1 << cursor_pos_;
+  uint16_t mask = mask_;
+
+  if (cursor_pos_ < num_slots_) {
+    // toggle slot active state; allow 0 mask
+    if (mask & m)
+      mask &= ~m;
+    else
+      mask |= m;
+    apply_mask(mask);
+  }
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::invert_mask() {
+  uint16_t m = ~(0xffffU << num_slots_);
+  uint16_t mask = mask_ ^ m;
+  apply_mask(mask);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::clear_mask() {
+  // clear the mask
+  apply_mask(0x00);
+  // and the user pattern:
+  owner_->clear_user_pattern(edit_this_sequence_);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::copy_sequence() {
+  owner_->copy_seq(edit_this_sequence_, num_slots_, mask_);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::paste_sequence() {
+  uint8_t newslots = owner_->paste_seq(edit_this_sequence_);
+  num_slots_ = newslots ? newslots  : num_slots_;
+  mask_ = owner_->get_mask(edit_this_sequence_);
+}
+
+template <typename Owner>
+/*static*/ uint16_t PatternEditor<Owner>::RotateMask(uint16_t mask, int num_slots, int amount) {
+  uint16_t used_bits = ~(0xffffU << num_slots);
+  mask &= used_bits;
+
+  if (amount < 0) {
+    amount = -amount % num_slots;
+    mask = (mask >> amount) | (mask << (num_slots - amount));
+  } else {
+    amount = amount % num_slots;
+    mask = (mask << amount) | (mask >> (num_slots - amount));
+  }
+  return mask | ~used_bits; // fill upper bits
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::BeginEditing() {
+
+  cursor_pos_ = 0;
+  uint8_t seq = owner_->get_sequence();
+  edit_this_sequence_ = seq;
+  num_slots_ = owner_->get_sequence_length(seq);
+  mask_ = owner_->get_mask(seq);
+}
+
+template <typename Owner>
+void PatternEditor<Owner>::Close() {
+  ui.SetButtonIgnoreMask();
+  owner_ = nullptr;
+}
+
+}; // namespace OC
+
+#endif // OC_PATTERN_EDIT_H_

--- a/software/o_c_REV/platformio.ini
+++ b/software/o_c_REV/platformio.ini
@@ -1,14 +1,18 @@
 ; PlatformIO Project Configuration File
 ;
-;   Build options: build flags, source filter, extra scripting
-;   Upload options: custom port, speed and extra flags
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
 ;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
 ; Please visit documentation for the other options and examples
-; http://docs.platformio.org/page/projectconf.html
+; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
 src_dir = .
-default_envs = oc_prod
+default_envs = 
+	oc_prod
+	oc_stock
 
 [env]
 platform = teensy@4.17.0
@@ -23,7 +27,21 @@ build_flags =
 upload_protocol = teensy-gui
 
 [env:oc_prod]
-build_flags = ${env.build_flags}
+build_flags = 
+	${env.build_flags}
+	-DENABLE_APP_ENIGMA
+	-DENABLE_APP_MIDI
+	-DENABLE_APP_NEURAL_NETWORK
+	-DENABLE_APP_PONG
+	-DENABLE_APP_DARKEST_TIMELINE
+
+[env:oc_stock]
+build_flags = 
+	${env.build_flags}
+	-DENABLE_APP_QUANTERMAIN
+	-DENABLE_APP_METAQ
+	-DENABLE_APP_CHORDS
+	-DENABLE_APP_SEQUINS
 
 [env:oc_dev]
 build_flags = ${env.build_flags} -DOC_DEV


### PR DESCRIPTION
This adds in Quantermain, Meta-Q, Sequins, and Acid Curds, at the expense of all the Hemisphere full-width apps. Mix & Match at your own risk in `OC_options.h`

In testing, the module fails to boot if the compiler reports RAM usage above 91% or so. Maybe if we can reduce dynamic memory allocations, we can push it further? There is also probably some code redundancy regarding scales, chords, Euclidean patterns, etc.